### PR TITLE
feat: terminal redesign — cyan phosphor aesthetic

### DIFF
--- a/docs/superpowers/plans/2026-03-12-terminal-redesign.md
+++ b/docs/superpowers/plans/2026-03-12-terminal-redesign.md
@@ -1,0 +1,979 @@
+# Terminal Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the generic dark/purple aesthetic with a terminal-inspired cyan phosphor design using JetBrains Mono throughout, subtle scanlines, and sharp-edged components.
+
+**Architecture:** All changes are CSS class and JSX restructuring within the existing Next.js 15 App Router static export. New files: `NavLinks.tsx` client component. Modified files: `globals.css`, `layout.tsx`, `page.tsx`, `ProjectCard.tsx`, `publications/page.tsx`, `resume/page.tsx`, `not-found.tsx`. No new npm packages; `JetBrains_Mono` is available via `next/font/google`.
+
+**Tech Stack:** Next.js 15 App Router, React 19, Tailwind CSS v4, TypeScript 5, Node 25. Static export (`next build` outputs to `site/out/`). CI runs `npm ci && npm run build` on PRs — no separate test runner.
+
+**Spec:** `docs/superpowers/specs/2026-03-12-terminal-redesign-design.md`
+
+**Local commands (run from `site/` directory):**
+- Dev server: `npm run dev`
+- Lint: `npm run lint`
+- Build (same as CI): `npm run build`
+
+---
+
+## Chunk 1: Branch Setup and Dependency Refresh
+
+### Task 1: Create feature branch
+
+**Files:** none
+
+- [ ] **Step 1: Create and checkout feature branch**
+
+```bash
+git checkout -b feat/terminal-redesign
+```
+
+- [ ] **Step 2: Refresh dependencies to latest patch versions**
+
+```bash
+cd site && npm install
+```
+
+- [ ] **Step 3: Verify baseline build passes before any changes**
+
+```bash
+cd site && npm run build
+```
+
+Expected: Build completes with no errors. Output in `site/out/`.
+
+- [ ] **Step 4: Verify baseline lint passes**
+
+```bash
+cd site && npm run lint
+```
+
+Expected: No lint errors.
+
+- [ ] **Step 5: Commit dependency refresh if package-lock.json changed**
+
+```bash
+git add site/package-lock.json && git diff --cached --stat
+# Only commit if lock file changed
+git commit -m "deps: refresh to latest patch versions"
+```
+
+---
+
+## Chunk 2: Foundation — CSS Theme and Font
+
+### Task 2: Rewrite `globals.css`
+
+**Files:**
+- Modify: `site/src/app/globals.css`
+
+This is the foundation. All other tasks depend on the CSS variables defined here being in place.
+
+- [ ] **Step 1: Replace `globals.css` entirely**
+
+```css
+@import "tailwindcss";
+
+@theme inline {
+  --color-background: #000a0a;
+  --color-foreground: #00e5e5;
+  --font-sans: var(--font-jetbrains-mono);
+  --font-mono: var(--font-jetbrains-mono);
+
+  /* Terminal color system */
+  --color-terminal-bg:        #000a0a;
+  --color-terminal-cyan:      #00e5e5;
+  --color-terminal-cyan-60:   rgba(0, 229, 229, 0.6);
+  --color-terminal-cyan-35:   rgba(0, 229, 229, 0.35);
+  --color-terminal-border:    rgba(0, 229, 229, 0.12);
+  --color-terminal-border-hv: rgba(0, 229, 229, 0.25);
+  --color-terminal-surface:   rgba(0, 229, 229, 0.02);
+}
+
+body {
+  background: #000a0a;
+  color: #00e5e5;
+  font-family: var(--font-jetbrains-mono), monospace;
+  overflow-y: auto;
+}
+
+/* Focus indicators (accessibility) */
+:focus-visible {
+  outline: 2px solid #00e5e5;
+  outline-offset: 2px;
+}
+
+/* Blinking block cursor */
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
+}
+
+.cursor-blink {
+  animation: blink 1.1s step-end infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cursor-blink {
+    animation: none;
+    opacity: 1;
+  }
+}
+```
+
+- [ ] **Step 2: Verify TypeScript still compiles**
+
+```bash
+cd site && npm run build 2>&1 | head -30
+```
+
+Expected: No TypeScript errors (build may fail on missing font variable — that's expected, fixed in Task 3).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/src/app/globals.css
+git commit -m "style: replace purple theme with terminal cyan system"
+```
+
+---
+
+## Chunk 3: Layout Foundation — Font, Scanline, Nav
+
+Tasks 3 and 4 in this chunk are **independent** and can run in parallel.
+
+### Task 3: Create `NavLinks.tsx` client component
+
+**Files:**
+- Create: `site/src/app/(components)/NavLinks.tsx`
+
+This is a new `"use client"` component that handles active-route highlighting. It must be created before `layout.tsx` is updated to import it.
+
+- [ ] **Step 1: Create `NavLinks.tsx`**
+
+```tsx
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const links = [
+  { href: "/", label: "Home" },
+  { href: "/publications", label: "Publications" },
+  { href: "/resume", label: "Resume / CV" },
+];
+
+const externalLinks = [
+  { href: "https://www.linkedin.com/in/jeffb0llinger", label: "LinkedIn" },
+  { href: "https://github.com/jkeychan", label: "GitHub" },
+];
+
+export function NavLinks() {
+  const pathname = usePathname();
+
+  return (
+    <div className="flex items-center gap-6 w-full">
+      <div className="flex items-center gap-6">
+        {links.map(({ href, label }) => (
+          <Link
+            key={href}
+            href={href}
+            className={
+              pathname === href
+                ? "text-[12px] tracking-[2px] uppercase text-[#00e5e5]"
+                : "text-[12px] tracking-[2px] uppercase text-[rgba(0,229,229,0.35)] hover:text-[#00e5e5]"
+            }
+          >
+            {label}
+          </Link>
+        ))}
+      </div>
+      <div className="ml-auto flex items-center gap-6">
+        {externalLinks.map(({ href, label }) => (
+          <a
+            key={href}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[12px] tracking-[2px] uppercase text-[rgba(0,229,229,0.35)] hover:text-[#00e5e5]"
+          >
+            {label}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd site && npx tsc --noEmit 2>&1 | head -20
+```
+
+Expected: No errors on the new file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/src/app/(components)/NavLinks.tsx
+git commit -m "feat: add NavLinks client component with active-route highlighting"
+```
+
+---
+
+### Task 4: Update `layout.tsx` — font, scanline, nav, skip link
+
+**Files:**
+- Modify: `site/src/app/layout.tsx`
+
+- [ ] **Step 1: Replace font import and body classes**
+
+Replace the top of the file:
+
+```tsx
+// OLD — remove these two imports:
+import { Geist, Geist_Mono } from "next/font/google";
+
+// NEW — replace with:
+import { JetBrains_Mono } from "next/font/google";
+import { NavLinks } from "./(components)/NavLinks";
+```
+
+Replace font instantiation (the two `const geistSans` / `const geistMono` blocks):
+
+```tsx
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
+  subsets: ["latin"],
+  weight: ["300", "400", "500", "700"],
+});
+```
+
+- [ ] **Step 2: Update `<body>` className**
+
+```tsx
+// OLD:
+<body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+
+// NEW:
+<body className={`${jetbrainsMono.variable} antialiased`}>
+```
+
+- [ ] **Step 3: Replace star-field div with scanline overlay**
+
+```tsx
+// OLD — remove this line entirely:
+<div className="star-field" aria-hidden="true" />
+
+// NEW — replace with:
+<div
+  aria-hidden="true"
+  style={{
+    position: "fixed",
+    inset: 0,
+    pointerEvents: "none",
+    zIndex: 50,
+    background:
+      "repeating-linear-gradient(0deg, transparent, transparent 3px, rgba(0,200,200,0.008) 3px, rgba(0,200,200,0.008) 4px)",
+  }}
+/>
+```
+
+- [ ] **Step 4: Update skip-to-content link classes**
+
+```tsx
+// OLD:
+className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:bg-purple-600 focus:text-white focus:px-4 focus:py-2 focus:rounded focus:text-sm focus:font-medium"
+
+// NEW:
+className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:bg-[#00e5e5] focus:text-black focus:px-4 focus:py-2 focus:text-[12px] focus:tracking-[2px] focus:uppercase focus:font-bold"
+```
+
+- [ ] **Step 5: Replace `<nav>` contents**
+
+Find the `<div>` that is the direct child of `<nav>` (currently contains the Home/Publications/Resume links and the LinkedIn/GitHub external links). Replace the entire div and everything inside it with:
+
+```tsx
+<div className="mx-auto max-w-5xl px-6 py-4 flex items-center">
+  <NavLinks />
+</div>
+```
+
+Also update the `<nav>` element's own classes:
+
+```tsx
+// OLD:
+<nav className="fixed top-0 left-0 right-0 z-10 backdrop-blur bg-black/10 border-b border-white/10" ...>
+
+// NEW:
+<nav className="fixed top-0 left-0 right-0 z-[60] backdrop-blur bg-[rgba(0,10,10,0.92)] border-b border-[rgba(0,229,229,0.12)]" ...>
+```
+
+- [ ] **Step 6: Update footer**
+
+```tsx
+// OLD:
+<footer className="mt-8 border-t border-white/10 text-white/60 text-sm">
+  <div className="mx-auto max-w-6xl px-4 py-6">
+    <p>&copy; Jeff Bollinger</p>
+  </div>
+</footer>
+
+// NEW:
+<footer className="mt-8 border-t border-[rgba(0,229,229,0.08)]">
+  <div className="mx-auto max-w-5xl px-6 py-6">
+    <p className="text-[11px] tracking-[2px] text-[rgba(0,229,229,0.2)]">
+      &copy; {new Date().getFullYear()} Jeff Bollinger
+    </p>
+  </div>
+</footer>
+```
+
+- [ ] **Step 7: Verify build**
+
+```bash
+cd site && npm run build 2>&1 | tail -20
+```
+
+Expected: Build completes successfully. Font variable resolves, no TypeScript errors.
+
+- [ ] **Step 8: Verify lint**
+
+```bash
+cd site && npm run lint
+```
+
+Expected: No errors.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add site/src/app/layout.tsx
+git commit -m "style: update layout with JetBrains Mono, scanline, terminal nav"
+```
+
+---
+
+## Chunk 4: Homepage Restructure
+
+### Task 5: Rewrite `page.tsx`
+
+**Files:**
+- Modify: `site/src/app/page.tsx`
+
+This task restructures the hero grid, removes TypewriterText and decorative SVG, adds the about block and skills row.
+
+- [ ] **Step 1: Update imports**
+
+Remove the `TypewriterText` import. Keep all others:
+
+```tsx
+import Image from "next/image";
+import Link from "next/link";
+import { ProjectCard } from "./(components)/ProjectCard";
+// (remove TypewriterText import)
+```
+
+- [ ] **Step 2: Replace the hero section JSX**
+
+Replace the entire `<section>` hero block (lines 85–138 in current file) with:
+
+```tsx
+<main className="min-h-[80vh] px-6 md:px-8 pt-8 pb-16 text-[#00e5e5]" id="main-content-inner">
+  {/* Hero */}
+  <section className="mx-auto max-w-5xl grid grid-cols-1 md:grid-cols-[1fr_auto] gap-14 items-start mb-16 pb-16 border-b border-[rgba(0,229,229,0.1)]">
+    <div>
+      <p className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-4">
+        // security author &amp; leader
+      </p>
+      <h1 className="text-[40px] md:text-[60px] font-bold tracking-tight text-[#00e5e5] [text-shadow:0_0_40px_rgba(0,229,229,0.3)] leading-none mb-5">
+        Jeff<br />Bollinger
+        <span
+          aria-hidden="true"
+          className="cursor-blink inline-block w-[4px] h-[50px] md:h-[62px] bg-[#00e5e5] align-middle ml-2 [box-shadow:0_0_10px_rgba(0,229,229,0.8)]"
+        />
+      </h1>
+      <p className="text-[13px] md:text-[14px] text-[rgba(0,229,229,0.6)] leading-[1.7] max-w-[440px] mb-8">
+        Author of <em>Crafting the Infosec Playbook</em>. Writing and speaking
+        on security operations, threat hunting, and incident response.
+      </p>
+      <div className="flex gap-3">
+        <Link
+          href="/publications"
+          className="bg-[#00e5e5] text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5"
+        >
+          Publications
+        </Link>
+        <Link
+          href="/resume"
+          className="bg-transparent text-[#00e5e5] text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+        >
+          Resume / CV
+        </Link>
+      </div>
+    </div>
+    <div>
+      <Image
+        src="/static/media/avatar.d355c64ac071e83edeabfc9c51f454d3.svg"
+        alt="Jeff Bollinger"
+        width={160}
+        height={160}
+        priority
+        className="w-36 h-36 md:w-40 md:h-40 border border-[rgba(0,229,229,0.25)] [box-shadow:0_0_30px_rgba(0,229,229,0.08)] [filter:saturate(0.5)_contrast(1.1)]"
+      />
+    </div>
+  </section>
+```
+
+- [ ] **Step 3: Add about block and skills row**
+
+After the hero section closing tag, add:
+
+```tsx
+  {/* About block */}
+  <div className="mx-auto max-w-5xl mb-8">
+    <div className="relative border border-[rgba(0,229,229,0.15)] bg-[rgba(0,229,229,0.02)] px-7 py-5">
+      <span className="absolute -top-[9px] left-4 bg-[#000a0a] px-2 text-[10px] tracking-[3px] uppercase text-[rgba(0,229,229,0.4)]">
+        about
+      </span>
+      <p className="text-[13px] text-[rgba(0,229,229,0.65)] leading-[1.8]">
+        Cybersecurity leader focused on building and running security operations
+        programs. Detection engineering, incident response, security
+        architecture, and growing high-performing teams.
+      </p>
+    </div>
+  </div>
+
+  {/* Skills */}
+  <div className="mx-auto max-w-5xl flex flex-wrap gap-2 mb-16">
+    {[
+      "Threat Detection",
+      "Incident Response",
+      "Detection Engineering",
+      "Security Architecture",
+      "Executive Leadership",
+      "Security Operations",
+      "Security Engineering",
+    ].map((skill) => (
+      <span
+        key={skill}
+        className="text-[11px] tracking-[1.5px] uppercase border border-[rgba(0,229,229,0.15)] bg-[rgba(0,229,229,0.03)] px-3 py-1.5 text-[rgba(0,229,229,0.5)]"
+      >
+        {skill}
+      </span>
+    ))}
+  </div>
+```
+
+- [ ] **Step 4: Update Recent Highlights section**
+
+Replace the current highlights section:
+
+```tsx
+  {/* Recent highlights */}
+  <section className="mx-auto max-w-5xl">
+    <h2 className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-6 pb-3 border-b border-[rgba(0,229,229,0.08)]">
+      // recent highlights
+    </h2>
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+      <ProjectCard
+        imageSrc="/static/media/cover-blue-edition.0781c7b04869f677781b.png"
+        title="Crafting the Infosec Playbook"
+        description="Co-authored book on building incident response programs and monitoring architecture."
+        linkHref="https://www.infosecplaybook.com/"
+        imageFit="contain"
+      />
+      <ProjectCard
+        imageSrc="/static/media/moonbase.498c0f55cde35211bd65.png"
+        title="(Re)building Threat Detection and Incident Response at LinkedIn"
+        description="How LinkedIn rebuilt its security operations platform and teams, scaling protection for employees and members."
+        linkHref="https://engineering.linkedin.com/blog/2022/-re-building-threat-detection-and-incident-response-at-linkedin"
+      />
+      <ProjectCard
+        imageSrc="/static/media/cloud.e6bacd0aae8c329e0edd.png"
+        title="Cloud Security Observability"
+        description="Discussion on enterprise-scale observability for detection and response (Google Cloud Security Podcast)."
+        linkHref="https://cloud.withgoogle.com/cloudsecurity/podcast/ep96-cloud-security-observability-for-detection-and-response/"
+      />
+    </div>
+  </section>
+</main>
+```
+
+- [ ] **Step 5: Verify TypeScript**
+
+```bash
+cd site && npx tsc --noEmit 2>&1
+```
+
+Expected: No errors.
+
+- [ ] **Step 6: Verify build**
+
+```bash
+cd site && npm run build 2>&1 | tail -10
+```
+
+Expected: Build completes successfully.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add site/src/app/page.tsx
+git commit -m "style: redesign homepage with terminal hero, about block, skills row"
+```
+
+---
+
+## Chunk 5: Shared Components
+
+### Task 6: Update `ProjectCard.tsx`
+
+**Files:**
+- Modify: `site/src/app/(components)/ProjectCard.tsx`
+
+- [ ] **Step 1: Replace the entire component**
+
+```tsx
+import Image from "next/image";
+import type { ProjectCardProps } from "@/types";
+
+export function ProjectCard({
+  imageSrc,
+  title,
+  description,
+  linkHref,
+  linkLabel = "Link",
+  imageFit = "cover",
+  imagePosition = "center",
+}: ProjectCardProps) {
+  const fitClass =
+    imageFit === "contain" ? "object-contain" : "object-cover";
+  const posClass =
+    imagePosition === "top"
+      ? "object-top"
+      : imagePosition === "bottom"
+        ? "object-bottom"
+        : imagePosition === "left"
+          ? "object-left"
+          : imagePosition === "right"
+            ? "object-right"
+            : "object-center";
+
+  return (
+    <div className="border border-[rgba(0,229,229,0.12)] bg-[rgba(0,229,229,0.02)] overflow-hidden flex flex-col h-full hover:border-[rgba(0,229,229,0.25)] hover:bg-[rgba(0,229,229,0.04)] transition-colors">
+      <div className="w-full h-56 md:h-64 bg-[#001010] overflow-hidden relative border-b border-[rgba(0,229,229,0.08)]">
+        <Image
+          src={imageSrc}
+          alt={title}
+          fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+          className={`${fitClass} ${posClass} [filter:saturate(0.5)_contrast(1.1)]`}
+        />
+      </div>
+      <div className="p-4 flex-1 flex flex-col">
+        <h3 className="text-[#00e5e5] text-[13px] font-bold mb-2 leading-snug">{title}</h3>
+        <p className="text-[rgba(0,229,229,0.45)] text-[11px] flex-1 leading-[1.6]">
+          {description}
+        </p>
+        <div className="mt-4">
+          <a
+            href={linkHref}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[10px] tracking-[2px] uppercase text-[rgba(0,229,229,0.6)] hover:text-[#00e5e5]"
+          >
+            {linkLabel} &rarr;
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify lint**
+
+```bash
+cd site && npm run lint
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/src/app/(components)/ProjectCard.tsx
+git commit -m "style: update ProjectCard with terminal aesthetic"
+```
+
+---
+
+## Chunk 6: Secondary Pages (run in parallel — no dependencies between them)
+
+Tasks 7, 8, and 9 touch independent files and can be executed simultaneously.
+
+### Task 7: Update `publications/page.tsx`
+
+**Files:**
+- Modify: `site/src/app/publications/page.tsx`
+
+- [ ] **Step 1: Update page header and styles**
+
+Replace the `<main>` block (everything inside the outer fragment after the schema scripts) with:
+
+```tsx
+<main className="min-h-screen px-6 md:px-8 pt-8 pb-16 text-[#00e5e5]">
+  {/* Page header */}
+  <div className="mx-auto max-w-5xl mb-12">
+    <p className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-4">
+      // writing, talks &amp; appearances
+    </p>
+    <h1 className="text-[40px] font-bold tracking-tight text-[#00e5e5] [text-shadow:0_0_30px_rgba(0,229,229,0.2)] leading-none mb-4">
+      Publications
+      <span className="text-[10px] tracking-[2px] border border-[rgba(0,229,229,0.15)] px-2.5 py-1 ml-4 align-middle font-normal">
+        {publications.length}
+      </span>
+    </h1>
+    <p className="text-[13px] text-[rgba(0,229,229,0.5)] leading-[1.7] max-w-[560px]">
+      A non-exhaustive collection of blogs, podcasts, articles, conference
+      talks, and other publications I&apos;ve created, co-created, or been
+      involved in.
+    </p>
+  </div>
+
+  {/* Grid */}
+  <div className="mx-auto max-w-5xl grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+    {visibleItems.map((p) => (
+      <ProjectCard key={p.title} {...p} />
+    ))}
+  </div>
+
+  {/* Load more */}
+  {visibleCount < publications.length && (
+    <div className="mx-auto max-w-5xl mt-12 pt-6 border-t border-[rgba(0,229,229,0.08)] flex items-center gap-6">
+      <button
+        onClick={() =>
+          setVisibleCount((prev) =>
+            Math.min(prev + 12, publications.length),
+          )
+        }
+        aria-label="Load more publications"
+        className="bg-transparent text-[#00e5e5] text-[11px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+      >
+        Load more
+      </button>
+      <span className="text-[11px] text-[rgba(0,229,229,0.25)] tracking-[1px]">
+        Showing {Math.min(visibleCount, publications.length)} of {publications.length}
+      </span>
+    </div>
+  )}
+
+  <div ref={sentinelRef} className="h-10" />
+</main>
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd site && npm run build 2>&1 | tail -10
+```
+
+Expected: Builds successfully.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/src/app/publications/page.tsx
+git commit -m "style: update publications page with terminal aesthetic"
+```
+
+---
+
+### Task 8: Update `resume/page.tsx`
+
+**Files:**
+- Modify: `site/src/app/resume/page.tsx`
+
+- [ ] **Step 1: Replace the `<main>` block**
+
+```tsx
+<main className="min-h-screen px-6 md:px-8 pt-8 pb-16 text-[#00e5e5]">
+  {/* Page header */}
+  <div className="mx-auto max-w-5xl mb-8">
+    <p className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-4">
+      // resume &amp; cv
+    </p>
+    <h1 className="text-[40px] font-bold tracking-tight text-[#00e5e5] [text-shadow:0_0_30px_rgba(0,229,229,0.2)] leading-none mb-8">
+      Resume / CV
+    </h1>
+    <div className="flex gap-3 mb-8">
+      <a
+        className="bg-[#00e5e5] text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5"
+        href="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.pdf"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        View PDF
+      </a>
+      <a
+        className="bg-transparent text-[#00e5e5] text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+        href="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.docx"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        Download DOCX
+      </a>
+    </div>
+    <div className="border border-[rgba(0,229,229,0.15)] overflow-hidden h-[80vh]">
+      <iframe
+        title="Jeff Bollinger Resume"
+        src="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.pdf"
+        className="w-full h-full"
+      />
+    </div>
+  </div>
+</main>
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd site && npm run build 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/src/app/resume/page.tsx
+git commit -m "style: update resume page with terminal aesthetic"
+```
+
+---
+
+### Task 9: Update `not-found.tsx`
+
+**Files:**
+- Modify: `site/src/app/not-found.tsx`
+
+- [ ] **Step 1: Replace the component**
+
+```tsx
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <main className="min-h-[70vh] flex flex-col items-center justify-center px-6 py-16 text-[#00e5e5] text-center">
+      <p className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-4">
+        // not found
+      </p>
+      <h1 className="text-[80px] font-bold tracking-tight text-[#00e5e5] [text-shadow:0_0_40px_rgba(0,229,229,0.3)] leading-none mb-4">
+        404
+      </h1>
+      <p className="text-[13px] text-[rgba(0,229,229,0.5)] mb-10 max-w-md leading-[1.7]">
+        The page you are looking for does not exist or may have been moved.
+      </p>
+      <div className="flex gap-3">
+        <Link
+          href="/"
+          className="bg-[#00e5e5] text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5"
+        >
+          Go Home
+        </Link>
+        <Link
+          href="/publications"
+          className="bg-transparent text-[#00e5e5] text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+        >
+          Publications
+        </Link>
+      </div>
+    </main>
+  );
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+cd site && npm run build 2>&1 | tail -10
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add site/src/app/not-found.tsx
+git commit -m "style: update 404 page with terminal aesthetic"
+```
+
+---
+
+## Chunk 7: Verification, Review, and PR
+
+Tasks 10–14 run after all implementation tasks complete. Tasks 10–13 can run in parallel.
+
+### Task 10: Full build and lint verification
+
+**Files:** none
+
+- [ ] **Step 1: Full clean build**
+
+```bash
+cd site && rm -rf .next out && npm run build
+```
+
+Expected: Exits 0. `site/out/` directory populated with static HTML.
+
+- [ ] **Step 2: Full lint pass**
+
+```bash
+cd site && npm run lint
+```
+
+Expected: No errors, no warnings that would become errors.
+
+- [ ] **Step 3: TypeScript strict check**
+
+```bash
+cd site && npx tsc --noEmit
+```
+
+Expected: No errors.
+
+---
+
+### Task 11: Dev server visual inspection
+
+**Files:** none
+
+- [ ] **Step 1: Start dev server**
+
+```bash
+cd site && npm run dev
+```
+
+- [ ] **Step 2: Check each route visually**
+
+Open `http://localhost:3000` and verify:
+
+| Route | Check |
+|-------|-------|
+| `/` | Hero with blinking cursor, about block, skills, 3 highlight cards |
+| `/publications` | Terminal heading with count badge, cyan cards, load-more button |
+| `/resume` | Terminal heading, cyan buttons, white-background-free iframe container |
+| `/404` | Navigate to `/doesnotexist` — see cyan 404 page |
+| Nav | Active link highlights correctly on each route |
+| Focus | Tab through page — focus rings are cyan, not purple |
+| Skip link | Tab once on any page — skip link appears in cyan |
+
+- [ ] **Step 3: Check reduced-motion**
+
+In browser DevTools → Rendering → Emulate CSS media feature `prefers-reduced-motion: reduce`. Verify the blinking cursor stops moving (stays visible at opacity 1).
+
+---
+
+### Task 12: Code review using `coderabbit:code-review` skill
+
+- [ ] **Step 1: Run code review**
+
+Use `coderabbit:code-review` skill on the changes in the `feat/terminal-redesign` branch.
+
+Focus areas: accessibility regressions, TypeScript correctness, any leftover purple/white classes from the old theme.
+
+- [ ] **Step 2: Address any blocking issues found**
+
+Fix issues, re-lint, re-build before proceeding.
+
+---
+
+### Task 13: Simplification pass using `code-simplifier:code-simplifier` skill
+
+- [ ] **Step 1: Run simplification**
+
+Use `code-simplifier:code-simplifier` skill on all modified files:
+- `site/src/app/globals.css`
+- `site/src/app/layout.tsx`
+- `site/src/app/(components)/NavLinks.tsx`
+- `site/src/app/(components)/ProjectCard.tsx`
+- `site/src/app/page.tsx`
+- `site/src/app/publications/page.tsx`
+- `site/src/app/resume/page.tsx`
+- `site/src/app/not-found.tsx`
+
+- [ ] **Step 2: Verify build and lint still pass after any simplifications**
+
+```bash
+cd site && npm run build && npm run lint
+```
+
+- [ ] **Step 3: Commit any simplification changes**
+
+```bash
+git add -p  # stage only simplification changes
+git commit -m "refactor: simplify terminal redesign implementation"
+```
+
+---
+
+### Task 14: Open PR
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin feat/terminal-redesign
+```
+
+- [ ] **Step 2: Create PR**
+
+```bash
+gh pr create \
+  --title "feat: terminal redesign — cyan phosphor aesthetic" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Replaces generic dark/purple palette with terminal-inspired cyan phosphor design
+- JetBrains Mono throughout; subtle scanline overlay; blinking block cursor on hero
+- Restructures homepage hero: label + name + cursor + bio + 2 CTAs + avatar column
+- Removes TypewriterText component usage and decorative SVG
+- Adds floating-label about block and skills tags row
+- New \`NavLinks\` client component with active-route highlighting via \`usePathname()\`
+- Updates all pages: publications, resume, 404
+- All existing SEO, structured data, and accessibility preserved
+
+## Test plan
+
+- [ ] CI passes: actionlint, zizmor, ratchet, \`npm run build\`
+- [ ] ESLint: \`npm run lint\` — no errors
+- [ ] TypeScript: \`npx tsc --noEmit\` — no errors
+- [ ] Visual: all routes render correctly in dev server
+- [ ] Accessibility: cyan focus rings, skip link, reduced-motion cursor
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Verify CI passes**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: All checks pass — actionlint, zizmor, ratchet, pages-preview build.
+
+---
+
+## Subagent Execution Notes
+
+When running via `superpowers:subagent-driven-development`:
+
+**Parallel groups** (dispatch simultaneously):
+- Group A (independent, run in parallel): Tasks 3 + 4 (NavLinks + layout)
+- Group B (run after Group A completes): Task 5 (homepage, depends on NavLinks)
+- Group C (run after Task 6 foundation is set): Tasks 7 + 8 + 9 (secondary pages, fully independent of each other)
+- Group D (run after all implementation): Tasks 10 + 11 + 12 + 13 (verification, visual, review, simplification — parallel)
+- Group E (final, sequential): Task 14 (PR creation)
+
+**Minimum 8 subagents** cover: Tasks 3, 4, 5, 6, 7, 8, 9 (implementation) + Task 10 (build) + Task 11 (visual) + Task 12 (code review) + Task 13 (simplification). Run Groups A, C, and D each as a parallel batch.

--- a/docs/superpowers/specs/2026-03-12-terminal-redesign-design.md
+++ b/docs/superpowers/specs/2026-03-12-terminal-redesign-design.md
@@ -1,0 +1,203 @@
+# Terminal Redesign — Design Spec
+
+**Date:** 2026-03-12
+**Status:** Approved
+
+---
+
+## Overview
+
+Redesign jeff-bollinger.com from its current generic dark/purple aesthetic to a terminal-inspired design with a cyan phosphor palette. The direction is "terminal-inspired, not theatrical" — strong monospace typography and phosphor glow atmosphere without fake command prompts or CLI theater. The goal is a site that feels specific to Jeff's identity as a security author and leader, not a generic tech portfolio.
+
+---
+
+## Design Direction
+
+### Aesthetic
+- **Style:** Terminal-inspired. Monospace throughout, cyan-on-near-black, subtle scanline texture.
+- **Tone:** No command prompts, no fake shell interactions. The *feeling* of a terminal — not a costume.
+- **Memorable element:** Full JetBrains Mono type system + blinking block cursor on hero name + phosphor cyan glow.
+
+### Color System
+
+All colors defined as CSS variables in `globals.css` `@theme` block:
+
+```css
+--color-terminal-bg:        #000a0a;
+--color-terminal-cyan:      #00e5e5;
+--color-terminal-cyan-60:   rgba(0, 229, 229, 0.6);
+--color-terminal-cyan-35:   rgba(0, 229, 229, 0.35);
+--color-terminal-border:    rgba(0, 229, 229, 0.12);   /* default borders */
+--color-terminal-border-hv: rgba(0, 229, 229, 0.25);   /* hover state borders */
+--color-terminal-surface:   rgba(0, 229, 229, 0.02);   /* card/block backgrounds */
+```
+
+Specific usages:
+- **Background (`body`):** solid `#000a0a` — replaces the `linear-gradient(270deg, #1b1429, #140f23)` currently in `globals.css` line 11
+- **Primary text:** `#00e5e5`
+- **Secondary text / body copy:** `rgba(0, 229, 229, 0.6)`
+- **Dim labels / section headings:** `rgba(0, 229, 229, 0.35)`
+- **Default borders:** `rgba(0, 229, 229, 0.12)`
+- **Hover borders:** `rgba(0, 229, 229, 0.25)`
+- **Card / block backgrounds:** `rgba(0, 229, 229, 0.02)`
+- **Scanline overlay:** CSS `repeating-linear-gradient` at 0.8% opacity
+
+### Typography
+
+- **Font family:** JetBrains Mono — weights 300, 400, 500, 700 — loaded via `next/font/google`
+- **Replaces:** Geist Sans and Geist Mono (both removed entirely)
+- **CSS variable:** `--font-jetbrains-mono` set as `--font-sans` and `--font-mono` in `@theme`
+- **Hero name:** `text-[40px] md:text-[60px]`, weight 700, `tracking-tight`, cyan `text-shadow: 0 0 40px rgba(0,229,229,0.3)`
+- **Section labels (`//` headings):** `text-[11px]`, `tracking-[4px]`, uppercase, `rgba(0,229,229,0.35)`, with bottom border rule
+- **Body copy:** `text-[13px] md:text-[14px]`, `leading-[1.7]`
+- **Buttons / tags / nav links:** `text-[10px] md:text-[12px]`, `tracking-[2px]`, uppercase
+
+### Scanline Overlay
+- A `<div>` in `RootLayout`, `position: fixed`, `inset: 0`, `pointer-events: none`, `aria-hidden="true"`, `z-index: 50`
+- CSS: `background: repeating-linear-gradient(0deg, transparent, transparent 3px, rgba(0,200,200,0.008) 3px, rgba(0,200,200,0.008) 4px)`
+- Nav sits at `z-index: 60` (above scanline)
+
+### Key UI Patterns
+
+- **No rounded corners anywhere:** Remove all `rounded`, `rounded-lg`, `rounded-full`, `rounded-md` from every element — buttons, cards, tags, avatar, skip link. The terminal aesthetic is sharp-edged throughout.
+- **Floating-label info blocks:** bordered box (`border`, `bg-terminal-surface`) with a label element `position: absolute; top: -8px; left: 18px` using `background: #000a0a` to cut out from the border line, `text-[10px] tracking-[3px] uppercase opacity-40`
+- **Blinking block cursor:** `<span aria-hidden="true">` — `inline-block w-[4px] h-[50px] md:h-[62px] bg-terminal-cyan align-middle ml-1.5 shadow-[0_0_10px_rgba(0,229,229,0.8)]` with class `cursor-blink` (defined in `globals.css`). Stops blinking under `prefers-reduced-motion` (stays visible, opacity 1).
+- **Section headings:** text prefixed with `//`, dim cyan, letter-spaced, with `border-b border-terminal-border pb-3 mb-6`
+- **Skill tags:** `text-[11px] tracking-[1.5px] uppercase border border-terminal-border bg-terminal-surface px-3 py-1.5`
+- **Cards:** `border border-terminal-border bg-terminal-surface overflow-hidden` with `hover:border-terminal-border-hv hover:bg-[rgba(0,229,229,0.04)]`
+- **Button primary:** `bg-terminal-cyan text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5`
+- **Button secondary:** `bg-transparent text-terminal-cyan text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-terminal-border hover:border-terminal-border-hv`
+- **Nav:** `fixed z-[60]`, `bg-[rgba(0,10,10,0.92)] backdrop-blur`, `border-b border-terminal-border`
+- **Image filter:** Apply `[filter:saturate(0.5)_contrast(1.1)]` as a Tailwind arbitrary-value class to all card and avatar images for palette cohesion. Do not use `saturate-50` or `contrast-110` utilities — use the single arbitrary class.
+
+### Focus Indicators
+- Update `globals.css` `:focus-visible` from purple-400 to: `outline: 2px solid #00e5e5; outline-offset: 2px`
+
+---
+
+## Files to Modify
+
+### `site/src/app/globals.css`
+1. Replace `@theme` block: remove Geist font variables, add JetBrains Mono variable and all `--color-terminal-*` tokens
+2. Replace `body` rule: `background: #000a0a`, `font-family: var(--font-jetbrains-mono), monospace`
+3. Update `:focus-visible`: change outline color from `#a78bfa` to `#00e5e5`
+4. Remove `.star-field`, `.star-field::before`, `.star-field::after`, and `@keyframes twinkle` entirely (dead code after layout change)
+5. Add cursor blink rules:
+```css
+@keyframes blink { 0%,100%{opacity:1} 50%{opacity:0} }
+.cursor-blink { animation: blink 1.1s step-end infinite; }
+@media (prefers-reduced-motion: reduce) { .cursor-blink { animation: none; opacity: 1; } }
+```
+
+### `site/src/app/layout.tsx`
+1. Replace `Geist` / `Geist_Mono` imports with `JetBrains_Mono` from `next/font/google` (weights: `['300','400','500','700']`, variable: `--font-jetbrains-mono`)
+2. Remove `star-field` `<div>` from JSX
+3. Add scanline overlay `<div>` with inline style or className: `fixed inset-0 pointer-events-none z-50 bg-[repeating-linear-gradient(...)]`, `aria-hidden="true"`
+4. Update nav: `z-[60]`, new color classes. Add active-link highlighting: extract nav links into a `NavLinks` client component at `site/src/app/(components)/NavLinks.tsx` with `"use client"` directive. It uses `usePathname()` from `next/navigation` — apply `text-terminal-cyan` to the link whose `href` exactly matches the current pathname, `text-terminal-cyan-35 hover:text-terminal-cyan` to all other links. Import and render `<NavLinks />` inside the `<nav>` in `layout.tsx`.
+5. Update skip-to-content link: replace `focus:bg-purple-600 focus:text-white` with `focus:bg-terminal-cyan focus:text-black`
+6. Update footer classes to new palette
+7. All structured data (Schema.org scripts) — **no changes**
+
+### `site/src/app/page.tsx`
+Restructure hero JSX. New layout:
+
+```
+<section> grid grid-cols-1 md:grid-cols-[1fr_auto] gap-14 items-start
+  <div> (text column)
+    label:  // security author & leader
+    h1:     Jeff\nBollinger + blinking cursor span
+    p:      bio text (keep existing copy)
+    div:    CTA buttons (Publications primary, Resume/CV secondary)
+  </div>
+  <div> (avatar column)
+    avatar image — square, no border-radius, thin cyan border, subtle glow shadow
+    filter: saturate(0.5) contrast(1.1)
+  </div>
+</section>
+
+<div> (about block — floating-label pattern)
+  label: "about"
+  content: condensed prose from existing "What I do" bullet list
+</div>
+
+<div> (skills row — flex wrap)
+  skill tags from existing "Core skills"
+</div>
+
+<section> (recent highlights)
+  section heading: // recent highlights
+  3-col ProjectCard grid (unchanged cards, new styles)
+</section>
+```
+
+Specific changes:
+- Remove `TypewriterText` component usage and import
+- Remove decorative SVG `<Image>` (the `home-main.bb0187d...svg`)
+- Remove the `lg:grid-cols-3` info section; replace with stacked about block + skills row
+- Avatar: keep same `src="/static/media/avatar.d355c64ac071e83edeabfc9c51f454d3.svg"`, dimensions `w-36 h-36 md:w-40 md:h-40` (144px / 160px), remove `rounded-full`, add `border border-terminal-border shadow-[0_0_30px_rgba(0,229,229,0.08)] [filter:saturate(0.5)_contrast(1.1)]`
+- "What I do" bullet list → condensed paragraph in about block: *"Cybersecurity leader focused on building and running security operations programs. Detection engineering, incident response, security architecture, and growing high-performing teams."*
+- Hero name: `text-[40px] md:text-[60px] font-bold tracking-tight` — remove `font-extrabold`, remove `text-purple-400` span wrapper (whole name is `text-terminal-cyan`)
+- Heading text change: remove "Hello I'm" prefix — just "Jeff\nBollinger" with a `<br>` and blinking cursor
+- Hero CTAs: two buttons only — "Publications" (primary) and "Resume / CV" (secondary). Remove the standalone LinkedIn CTA button from the hero; LinkedIn remains accessible in the nav.
+
+### `site/src/app/publications/page.tsx`
+1. Update page heading to match new pattern: `// writing, talks & appearances` label, then `<h1>Publications</h1>` (change existing h1 text from "Publications and Conferences" to "Publications"). After the h1 text, inline a count badge: `<span className="text-[10px] tracking-[2px] border border-terminal-border px-2.5 py-1 ml-4 align-middle">{publications.length}</span>`. The `publications` array is already imported in the file so `publications.length` is available directly — no additional data fetching needed.
+2. Add subtitle paragraph (content from existing page or new brief copy)
+3. Update all color/border classes to new palette
+4. Add active nav state (handled by `NavLinks` client component in layout)
+5. Keep: IntersectionObserver lazy loading, load-more button, all structured data
+
+### `site/src/app/resume/page.tsx`
+1. Add page header: `// resume & cv` label + `<h1>Resume / CV</h1>` using new heading pattern
+2. Update download buttons to primary/secondary button styles (remove `rounded`)
+3. Update iframe container: replace `bg-white rounded overflow-hidden h-[80vh]` with `bg-transparent border border-terminal-border overflow-hidden h-[80vh]`
+4. Keep: PDF/DOCX download links, embedded iframe
+
+### `site/src/app/not-found.tsx`
+1. `// 404` as section label
+2. `<h1>404</h1>` in `text-[60px] font-bold text-terminal-cyan`
+3. Brief message and links back to home/publications using new link style
+4. Remove purple color class
+
+### `site/src/app/(components)/ProjectCard.tsx`
+1. Update className strings: borders → `border-terminal-border`, backgrounds → `bg-terminal-surface`, text colors → new palette
+2. Remove inline `style={{ textAlign: "justify" }}` from description element (line ~41)
+3. Link/CTA button → new secondary button style
+4. Image: add Tailwind arbitrary-value class `[filter:saturate(0.5)_contrast(1.1)]` for palette cohesion. Do not use `saturate-50` or `contrast-110` utilities.
+
+### `site/src/app/(components)/TypewriterText.tsx`
+- No changes needed (component is no longer used on the homepage)
+- Do not delete — may be used elsewhere or in future
+
+---
+
+## Dependencies
+
+All dependencies are already at latest major versions. On implementation:
+- Run `npm install` in `/site` to pull latest patch/minor versions
+- Add `JetBrains_Mono` to the font import — no new packages needed
+- Remove `Geist` and `Geist_Mono` font imports
+
+---
+
+## What Is Preserved (Do Not Change)
+
+- All Schema.org structured data (`lib/schema.ts`, layout, page files)
+- All SEO metadata (title, description, OG tags, Twitter card)
+- All ARIA labels, semantic HTML, heading hierarchy, `prefers-reduced-motion` handling
+- IntersectionObserver lazy loading on publications page
+- `publications/data.ts` — no data changes
+- `types.ts` — no type changes
+- `lib/schema.ts` — no changes
+- Static export configuration (`next.config.ts`)
+- CI/CD workflows
+- `.nvmrc` (Node 25)
+
+---
+
+## Out of Scope
+
+- Content changes beyond what is explicitly called out above
+- New pages or routes
+- Any backend or data layer changes
+- Adding new npm packages

--- a/site/src/app/(components)/NavLinks.tsx
+++ b/site/src/app/(components)/NavLinks.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const links = [
+  { href: "/", label: "Home" },
+  { href: "/publications", label: "Publications" },
+  { href: "/resume", label: "Resume / CV" },
+];
+
+const externalLinks = [
+  { href: "https://www.linkedin.com/in/jeffb0llinger", label: "LinkedIn" },
+  { href: "https://github.com/jkeychan", label: "GitHub" },
+];
+
+export function NavLinks() {
+  const pathname = usePathname();
+
+  return (
+    <div className="flex items-center gap-6 w-full">
+      <div className="flex items-center gap-6">
+        {links.map(({ href, label }) => (
+          <Link
+            key={href}
+            href={href}
+            className={
+              pathname === href
+                ? "text-[12px] tracking-[2px] uppercase text-[#00e5e5]"
+                : "text-[12px] tracking-[2px] uppercase text-[rgba(0,229,229,0.35)] hover:text-[#00e5e5]"
+            }
+          >
+            {label}
+          </Link>
+        ))}
+      </div>
+      <div className="ml-auto flex items-center gap-6">
+        {externalLinks.map(({ href, label }) => (
+          <a
+            key={href}
+            href={href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-[12px] tracking-[2px] uppercase text-[rgba(0,229,229,0.35)] hover:text-[#00e5e5]"
+          >
+            {label}
+          </a>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/site/src/app/(components)/NavLinks.tsx
+++ b/site/src/app/(components)/NavLinks.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
-const NAV_LINK_BASE = "text-[12px] tracking-[2px] uppercase";
+const NAV_LINK_BASE = "text-[12px] tracking-[2px] uppercase transition-colors";
+const NAV_LINK_ACTIVE = `${NAV_LINK_BASE} text-terminal-cyan border-b border-terminal-cyan`;
 const NAV_LINK_INACTIVE = `${NAV_LINK_BASE} text-terminal-cyan-35 hover:text-terminal-cyan`;
 
 const links = [
@@ -13,7 +14,7 @@ const links = [
 ];
 
 const externalLinks = [
-  { href: "https://www.linkedin.com/in/jeffb0llinger", label: "LinkedIn" },
+  { href: "https://www.linkedin.com/in/jeffb0llinger/", label: "LinkedIn" },
   { href: "https://github.com/jkeychan", label: "GitHub" },
 ];
 
@@ -29,7 +30,7 @@ export function NavLinks() {
             href={href}
             className={
               pathname === href
-                ? `${NAV_LINK_BASE} text-terminal-cyan`
+                ? NAV_LINK_ACTIVE
                 : NAV_LINK_INACTIVE
             }
           >
@@ -45,6 +46,7 @@ export function NavLinks() {
             target="_blank"
             rel="noopener noreferrer"
             className={NAV_LINK_INACTIVE}
+            aria-label={`${label} (opens in new tab)`}
           >
             {label}
           </a>

--- a/site/src/app/(components)/NavLinks.tsx
+++ b/site/src/app/(components)/NavLinks.tsx
@@ -3,6 +3,9 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 
+const NAV_LINK_BASE = "text-[12px] tracking-[2px] uppercase";
+const NAV_LINK_INACTIVE = `${NAV_LINK_BASE} text-terminal-cyan-35 hover:text-terminal-cyan`;
+
 const links = [
   { href: "/", label: "Home" },
   { href: "/publications", label: "Publications" },
@@ -26,8 +29,8 @@ export function NavLinks() {
             href={href}
             className={
               pathname === href
-                ? "text-[12px] tracking-[2px] uppercase text-[#00e5e5]"
-                : "text-[12px] tracking-[2px] uppercase text-[rgba(0,229,229,0.35)] hover:text-[#00e5e5]"
+                ? `${NAV_LINK_BASE} text-terminal-cyan`
+                : NAV_LINK_INACTIVE
             }
           >
             {label}
@@ -41,7 +44,7 @@ export function NavLinks() {
             href={href}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-[12px] tracking-[2px] uppercase text-[rgba(0,229,229,0.35)] hover:text-[#00e5e5]"
+            className={NAV_LINK_INACTIVE}
           >
             {label}
           </a>

--- a/site/src/app/(components)/ProjectCard.tsx
+++ b/site/src/app/(components)/ProjectCard.tsx
@@ -24,22 +24,19 @@ export function ProjectCard({
             : "object-center";
 
   return (
-    <div className="bg-white/5 border border-white/10 rounded-lg overflow-hidden shadow-md flex flex-col h-full">
-      <div className="w-full h-56 md:h-64 bg-black/20 overflow-hidden relative">
+    <div className="border border-[rgba(0,229,229,0.12)] bg-[rgba(0,229,229,0.02)] overflow-hidden flex flex-col h-full hover:border-[rgba(0,229,229,0.25)] hover:bg-[rgba(0,229,229,0.04)] transition-colors">
+      <div className="w-full h-56 md:h-64 bg-[#001010] overflow-hidden relative border-b border-[rgba(0,229,229,0.08)]">
         <Image
           src={imageSrc}
           alt={title}
           fill
           sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
-          className={`${fitClass} ${posClass}`}
+          className={`${fitClass} ${posClass} [filter:saturate(0.5)_contrast(1.1)]`}
         />
       </div>
       <div className="p-4 flex-1 flex flex-col">
-        <h3 className="text-white text-lg font-semibold mb-2">{title}</h3>
-        <p
-          className="text-white/80 text-sm flex-1"
-          style={{ textAlign: "justify" }}
-        >
+        <h3 className="text-[#00e5e5] text-[13px] font-bold mb-2 leading-snug">{title}</h3>
+        <p className="text-[rgba(0,229,229,0.45)] text-[11px] flex-1 leading-[1.6]">
           {description}
         </p>
         <div className="mt-4">
@@ -47,9 +44,9 @@ export function ProjectCard({
             href={linkHref}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 bg-purple-600 hover:bg-purple-500 text-white text-sm font-medium px-3 py-2 rounded"
+            className="text-[10px] tracking-[2px] uppercase text-[rgba(0,229,229,0.6)] hover:text-[#00e5e5]"
           >
-            {linkLabel}
+            {linkLabel} &rarr;
           </a>
         </div>
       </div>

--- a/site/src/app/(components)/ProjectCard.tsx
+++ b/site/src/app/(components)/ProjectCard.tsx
@@ -23,7 +23,7 @@ export function ProjectCard({
   const posClass = positionMap[imagePosition] ?? "object-center";
 
   return (
-    <div className="border border-terminal-border bg-terminal-surface overflow-hidden flex flex-col h-full hover:border-terminal-border-hv hover:bg-[rgba(0,229,229,0.04)] transition-colors">
+    <div className="card-pulse border-2 border-[rgba(0,229,229,0.22)] bg-terminal-surface overflow-hidden flex flex-col h-full hover:border-[rgba(0,229,229,0.45)] hover:bg-[rgba(0,229,229,0.04)] transition-colors">
       <div className="w-full h-56 md:h-64 bg-[#001010] overflow-hidden relative border-b border-[rgba(0,229,229,0.08)]">
         <Image
           src={imageSrc}

--- a/site/src/app/(components)/ProjectCard.tsx
+++ b/site/src/app/(components)/ProjectCard.tsx
@@ -12,19 +12,18 @@ export function ProjectCard({
 }: ProjectCardProps) {
   const fitClass =
     imageFit === "contain" ? "object-contain" : "object-cover";
-  const posClass =
-    imagePosition === "top"
-      ? "object-top"
-      : imagePosition === "bottom"
-        ? "object-bottom"
-        : imagePosition === "left"
-          ? "object-left"
-          : imagePosition === "right"
-            ? "object-right"
-            : "object-center";
+
+  const positionMap: Record<string, string> = {
+    top: "object-top",
+    bottom: "object-bottom",
+    left: "object-left",
+    right: "object-right",
+    center: "object-center",
+  };
+  const posClass = positionMap[imagePosition] ?? "object-center";
 
   return (
-    <div className="border border-[rgba(0,229,229,0.12)] bg-[rgba(0,229,229,0.02)] overflow-hidden flex flex-col h-full hover:border-[rgba(0,229,229,0.25)] hover:bg-[rgba(0,229,229,0.04)] transition-colors">
+    <div className="border border-terminal-border bg-terminal-surface overflow-hidden flex flex-col h-full hover:border-terminal-border-hv hover:bg-[rgba(0,229,229,0.04)] transition-colors">
       <div className="w-full h-56 md:h-64 bg-[#001010] overflow-hidden relative border-b border-[rgba(0,229,229,0.08)]">
         <Image
           src={imageSrc}
@@ -35,7 +34,7 @@ export function ProjectCard({
         />
       </div>
       <div className="p-4 flex-1 flex flex-col">
-        <h3 className="text-[#00e5e5] text-[13px] font-bold mb-2 leading-snug">{title}</h3>
+        <h3 className="text-terminal-cyan text-[13px] font-bold mb-2 leading-snug">{title}</h3>
         <p className="text-[rgba(0,229,229,0.45)] text-[11px] flex-1 leading-[1.6]">
           {description}
         </p>
@@ -44,7 +43,7 @@ export function ProjectCard({
             href={linkHref}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-[10px] tracking-[2px] uppercase text-[rgba(0,229,229,0.6)] hover:text-[#00e5e5]"
+            className="text-[10px] tracking-[2px] uppercase text-terminal-cyan-60 hover:text-terminal-cyan"
           >
             {linkLabel} &rarr;
           </a>

--- a/site/src/app/(components)/PublicationsTerminal.tsx
+++ b/site/src/app/(components)/PublicationsTerminal.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type Props = { total: number; onDone: () => void };
+
+// Derive unix-style filenames from publication titles
+function toFilename(title: string): string {
+  return (
+    title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "")
+      .slice(0, 48) + ".md"
+  );
+}
+
+const SAMPLE_TITLES = [
+  "(Re)building Threat Detection and Incident Response at LinkedIn",
+  "Crafting the Infosec Playbook",
+  "Disk Image Deception",
+  "The Right Data at the Right Time",
+  "Cognitive Bias in Incident Response",
+  "CSIRT Schiltron: Training, Techniques, and Talent",
+  "How Computer Incident Response Teams Use CTI",
+  "Incident Detection and Response",
+  "Ad-Weary Or, What Could Possibly Go Wrong",
+  "FIRST Technical Colloquium Amsterdam",
+  "The State of Web Security: Attack and Response",
+  "Cloud Security Observability for Detection and Response",
+];
+
+const SIZES = ["24K", "148K", "18K", "32K", "21K", "44K", "38K", "29K", "17K", "52K", "36K", "27K"];
+
+export function PublicationsTerminal({ total, onDone }: Props) {
+  const [lines, setLines] = useState<string[]>([]);
+  const [phase, setPhase] = useState<"cmd" | "extracting" | "done">("cmd");
+  const prefersReduced = useRef(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    prefersReduced.current = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+    if (prefersReduced.current) {
+      onDone();
+      return;
+    }
+
+    // Short pause then start extraction
+    const t = setTimeout(() => setPhase("extracting"), 600);
+    return () => clearTimeout(t);
+  }, [onDone]);
+
+  useEffect(() => {
+    if (phase !== "extracting") return;
+
+    const filenames = SAMPLE_TITLES.map(toFilename);
+    let i = 0;
+
+    const iv = setInterval(() => {
+      if (i < filenames.length) {
+        const size = SIZES[i] ?? "22K";
+        setLines((prev) => [...prev, `x  experience/${filenames[i]}  (${size})`]);
+        i++;
+      } else {
+        clearInterval(iv);
+        const remaining = total - filenames.length;
+        setTimeout(() => {
+          setLines((prev) => [
+            ...prev,
+            `... ${remaining} more archived entries`,
+            ``,
+            `${total} files extracted.`,
+          ]);
+          setPhase("done");
+        }, 200);
+      }
+    }, 75);
+
+    return () => clearInterval(iv);
+  }, [phase, total]);
+
+  // Auto-scroll terminal output
+  useEffect(() => {
+    if (containerRef.current) {
+      containerRef.current.scrollTop = containerRef.current.scrollHeight;
+    }
+  }, [lines]);
+
+  useEffect(() => {
+    if (phase !== "done") return;
+    const t = setTimeout(onDone, 900);
+    return () => clearTimeout(t);
+  }, [phase, onDone]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="bg-terminal-bg text-[12px] leading-[1.85] p-6 overflow-y-auto h-64 border border-[rgba(0,229,229,0.15)] mb-8"
+      aria-live="polite"
+      aria-label="Extracting publications archive"
+    >
+      {/* Command line */}
+      <div className="mb-1">
+        <span className="text-terminal-cyan">jeff@terminal</span>
+        <span className="text-terminal-cyan-35">:</span>
+        <span className="text-[rgba(0,229,229,0.5)]">~</span>
+        <span className="text-terminal-cyan-35"> $ </span>
+        <span className="text-terminal-cyan">
+          tar -xzvf experience.tar.gz --directory=./experience
+        </span>
+      </div>
+
+      {/* Extracted filenames */}
+      {lines.map((line, i) =>
+        line === "" ? (
+          <div key={i} className="h-[1.85em]" />
+        ) : line.startsWith("...") ? (
+          <div key={i} className="text-[rgba(0,229,229,0.3)] italic">{line}</div>
+        ) : line.endsWith("extracted.") ? (
+          <div key={i} className="text-terminal-cyan mt-1 font-bold">{line}</div>
+        ) : (
+          <div key={i} className="text-terminal-cyan-35">
+            <span className="text-[rgba(0,229,229,0.5)]">x  </span>
+            <span className="text-terminal-cyan">
+              {line.replace(/^x  /, "").split("  ")[0]}
+            </span>
+            <span className="text-[rgba(0,229,229,0.25)]">
+              {"  " + (line.split("  ").pop() ?? "")}
+            </span>
+          </div>
+        )
+      )}
+
+      {/* Idle cursor while waiting */}
+      {phase === "cmd" && (
+        <span
+          aria-hidden="true"
+          className="cursor-blink inline-block w-[8px] h-[13px] bg-terminal-cyan align-middle"
+        />
+      )}
+
+      {/* Done line with blinking cursor */}
+      {phase === "done" && (
+        <div className="mt-2">
+          <span className="text-terminal-cyan">jeff@terminal</span>
+          <span className="text-terminal-cyan-35">:</span>
+          <span className="text-[rgba(0,229,229,0.5)]">~</span>
+          <span className="text-terminal-cyan-35"> $ </span>
+          <span className="text-terminal-cyan">ls -1 experience/ | head -5</span>
+          <br />
+          {SAMPLE_TITLES.slice(0, 5).map((t) => (
+            <div key={t} className="text-terminal-cyan-35 pl-2">
+              {toFilename(t)}
+            </div>
+          ))}
+          <div className="text-terminal-cyan-35 pl-2 italic">
+            ... and {total - 5} more
+          </div>
+          <div className="mt-2">
+            <span className="text-terminal-cyan">jeff@terminal</span>
+            <span className="text-terminal-cyan-35">:</span>
+            <span className="text-[rgba(0,229,229,0.5)]">~</span>
+            <span className="text-terminal-cyan-35"> $ </span>
+            <span
+              aria-hidden="true"
+              className="cursor-blink inline-block w-[8px] h-[13px] bg-terminal-cyan align-middle"
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/site/src/app/(components)/ResumeViewer.tsx
+++ b/site/src/app/(components)/ResumeViewer.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const PDF_SRC =
+  "/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.pdf";
+
+type Phase = "ls" | "open" | "progress" | "done" | "viewer";
+
+function ProgressBar({ value }: { value: number }) {
+  const filled = Math.floor(value / 5);
+  return (
+    <span>
+      <span className="text-terminal-cyan">{"█".repeat(filled)}</span>
+      <span className="text-[rgba(0,229,229,0.2)]">{"░".repeat(20 - filled)}</span>
+    </span>
+  );
+}
+
+export function ResumeViewer() {
+  const [phase, setPhase] = useState<Phase>("ls");
+  const [progress, setProgress] = useState(0);
+  const prefersReduced = useRef(false);
+
+  useEffect(() => {
+    prefersReduced.current = window.matchMedia(
+      "(prefers-reduced-motion: reduce)"
+    ).matches;
+    if (prefersReduced.current) {
+      setPhase("viewer");
+      return;
+    }
+    const t1 = setTimeout(() => setPhase("open"), 700);
+    const t2 = setTimeout(() => setPhase("progress"), 1300);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (phase !== "progress") return;
+    let p = 0;
+    const iv = setInterval(() => {
+      p = Math.min(p + Math.random() * 18 + 4, 100);
+      setProgress(Math.floor(p));
+      if (p >= 100) {
+        clearInterval(iv);
+        setTimeout(() => setPhase("done"), 200);
+      }
+    }, 60);
+    return () => clearInterval(iv);
+  }, [phase]);
+
+  useEffect(() => {
+    if (phase !== "done") return;
+    const t = setTimeout(() => setPhase("viewer"), 700);
+    return () => clearTimeout(t);
+  }, [phase]);
+
+  if (phase === "viewer") {
+    return (
+      <div className="w-full h-full animate-fade-in">
+        <iframe
+          title="Jeff Bollinger Resume"
+          src={PDF_SRC}
+          className="w-full h-full"
+        >
+          <p className="text-[12px] text-terminal-cyan-35 p-4">
+            PDF preview unavailable.{" "}
+            <a
+              href={PDF_SRC}
+              className="text-terminal-cyan underline"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Download PDF directly
+            </a>
+          </p>
+        </iframe>
+      </div>
+    );
+  }
+
+  return (
+    <div className="w-full h-full bg-terminal-bg p-6 text-[13px] leading-[1.9] overflow-hidden">
+      {/* ls command */}
+      <div>
+        <span className="text-terminal-cyan">jeff@terminal</span>
+        <span className="text-terminal-cyan-35">:</span>
+        <span className="text-[rgba(0,229,229,0.5)]">~/documents/resume</span>
+        <span className="text-terminal-cyan-35"> $ </span>
+        <span className="text-terminal-cyan">ls -lh</span>
+      </div>
+
+      {/* ls output */}
+      {phase !== "ls" && (
+        <div className="mt-1 mb-3">
+          <div className="grid grid-cols-[auto_1fr_auto] gap-x-4 text-terminal-cyan-35">
+            <span>-rw-r--r--</span>
+            <span className="text-terminal-cyan font-bold">
+              Jeff_Bollinger-Resume-2023-redacted.pdf
+            </span>
+            <span>148K</span>
+          </div>
+          <div className="grid grid-cols-[auto_1fr_auto] gap-x-4 text-terminal-cyan-35">
+            <span>-rw-r--r--</span>
+            <span>Jeff_Bollinger-Resume-2023-redacted.docx</span>
+            <span>82K</span>
+          </div>
+        </div>
+      )}
+
+      {/* open command */}
+      {(phase === "open" || phase === "progress" || phase === "done") && (
+        <div>
+          <span className="text-terminal-cyan">jeff@terminal</span>
+          <span className="text-terminal-cyan-35">:</span>
+          <span className="text-[rgba(0,229,229,0.5)]">~/documents/resume</span>
+          <span className="text-terminal-cyan-35"> $ </span>
+          <span className="text-terminal-cyan">
+            open Jeff_Bollinger-Resume-2023-redacted.pdf
+          </span>
+        </div>
+      )}
+
+      {/* progress bar */}
+      {(phase === "progress" || phase === "done") && (
+        <div className="mt-2 text-terminal-cyan-35">
+          <div>
+            Rendering pages{" "}
+            <ProgressBar value={progress} />{" "}
+            <span className="text-terminal-cyan">{progress}%</span>
+          </div>
+        </div>
+      )}
+
+      {/* done */}
+      {phase === "done" && (
+        <div className="mt-1 text-terminal-cyan">
+          Document ready.{" "}
+          <span className="text-terminal-cyan-35">Launching viewer</span>
+          <span className="cursor-blink inline-block w-[8px] h-[13px] bg-terminal-cyan align-middle ml-1" aria-hidden="true" />
+        </div>
+      )}
+
+      {/* idle cursor on ls phase */}
+      {phase === "ls" && (
+        <span
+          className="cursor-blink inline-block w-[8px] h-[13px] bg-terminal-cyan align-middle ml-1"
+          aria-hidden="true"
+        />
+      )}
+    </div>
+  );
+}

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -17,15 +17,15 @@
 }
 
 body {
-  background: #000a0a;
-  color: #00e5e5;
+  background: var(--color-terminal-bg);
+  color: var(--color-terminal-cyan);
   font-family: var(--font-jetbrains-mono), monospace;
   overflow-y: auto;
 }
 
 /* Focus indicators (accessibility) */
 :focus-visible {
-  outline: 2px solid #00e5e5;
+  outline: 2px solid var(--color-terminal-cyan);
   outline-offset: 2px;
 }
 

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -20,7 +20,6 @@ body {
   background: var(--color-terminal-bg);
   color: var(--color-terminal-cyan);
   font-family: var(--font-jetbrains-mono), monospace;
-  overflow-y: auto;
 }
 
 /* Focus indicators (accessibility) */

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -1,65 +1,47 @@
 @import "tailwindcss";
 
 @theme inline {
-  --color-background: #0a0a0a;
-  --color-foreground: #ededed;
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --color-background: #000a0a;
+  --color-foreground: #00e5e5;
+  --font-sans: var(--font-jetbrains-mono);
+  --font-mono: var(--font-jetbrains-mono);
+
+  /* Terminal color system */
+  --color-terminal-bg:        #000a0a;
+  --color-terminal-cyan:      #00e5e5;
+  --color-terminal-cyan-60:   rgba(0, 229, 229, 0.6);
+  --color-terminal-cyan-35:   rgba(0, 229, 229, 0.35);
+  --color-terminal-border:    rgba(0, 229, 229, 0.12);
+  --color-terminal-border-hv: rgba(0, 229, 229, 0.25);
+  --color-terminal-surface:   rgba(0, 229, 229, 0.02);
 }
 
 body {
-  background: linear-gradient(270deg, #1b1429, #140f23);
-  color: var(--color-foreground);
-  font-family: var(--font-geist-sans), Arial, Helvetica, sans-serif;
+  background: #000a0a;
+  color: #00e5e5;
+  font-family: var(--font-jetbrains-mono), monospace;
   overflow-y: auto;
 }
 
-/* ── Focus indicators (accessibility) ── */
+/* Focus indicators (accessibility) */
 :focus-visible {
-  outline: 2px solid #a78bfa; /* purple-400 */
+  outline: 2px solid #00e5e5;
   outline-offset: 2px;
 }
 
-/* ── Star field background ── */
-@keyframes twinkle {
-  from { opacity: 0.2; }
-  50%  { opacity: 1; }
-  to   { opacity: 0.2; }
+/* Blinking block cursor */
+@keyframes blink {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0; }
 }
 
-.star-field {
-  position: fixed;
-  inset: 0;
-  pointer-events: none;
-  z-index: -1;
+.cursor-blink {
+  animation: blink 1.1s step-end infinite;
 }
 
-.star-field::before,
-.star-field::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  will-change: opacity;
-  background-image:
-    radial-gradient(2px 2px at 20% 30%, rgba(255,255,255,0.6), transparent 60%),
-    radial-gradient(1.5px 1.5px at 70% 40%, rgba(255,255,255,0.5), transparent 60%),
-    radial-gradient(1.5px 1.5px at 40% 80%, rgba(255,255,255,0.4), transparent 60%),
-    radial-gradient(2px 2px at 80% 20%, rgba(255,255,255,0.6), transparent 60%),
-    radial-gradient(1px 1px at 10% 70%, rgba(255,255,255,0.5), transparent 60%);
-  background-repeat: no-repeat;
-  animation: twinkle 6s infinite ease-in-out;
-}
-
-.star-field::after {
-  transform: scale(1.2);
-  filter: blur(0.5px);
-  animation-duration: 9s;
-}
-
-/* ── Respect reduced motion preference ── */
 @media (prefers-reduced-motion: reduce) {
-  .star-field::before,
-  .star-field::after {
+  .cursor-blink {
     animation: none;
+    opacity: 1;
   }
 }

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -45,6 +45,16 @@ body {
   }
 }
 
+/* Fade-in for PDF viewer reveal */
+@keyframes fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.animate-fade-in {
+  animation: fade-in 0.6s ease-out forwards;
+}
+
 /* Gentle border glow pulse for cards and featured images */
 @keyframes border-pulse {
   0%, 100% { box-shadow: 0 0 4px rgba(0, 229, 229, 0.08); }

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -47,8 +47,8 @@ body {
 
 /* Gentle border glow pulse for cards and featured images */
 @keyframes border-pulse {
-  0%, 100% { box-shadow: 0 0 0   rgba(0, 229, 229, 0); }
-  50%       { box-shadow: 0 0 14px rgba(0, 229, 229, 0.18); }
+  0%, 100% { box-shadow: 0 0 4px rgba(0, 229, 229, 0.08); }
+  50%       { box-shadow: 0 0 22px rgba(0, 229, 229, 0.55), 0 0 6px rgba(0, 229, 229, 0.3); }
 }
 
 .card-pulse {

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -45,3 +45,19 @@ body {
     opacity: 1;
   }
 }
+
+/* Gentle border glow pulse for cards and featured images */
+@keyframes border-pulse {
+  0%, 100% { box-shadow: 0 0 0   rgba(0, 229, 229, 0); }
+  50%       { box-shadow: 0 0 14px rgba(0, 229, 229, 0.18); }
+}
+
+.card-pulse {
+  animation: border-pulse 3.5s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card-pulse {
+    animation: none;
+  }
+}

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -87,7 +87,7 @@ export default function RootLayout({
       >
         <a
           href="#main-content"
-          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:bg-[#00e5e5] focus:text-black focus:px-4 focus:py-2 focus:text-[12px] focus:tracking-[2px] focus:uppercase focus:font-bold"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:bg-terminal-cyan focus:text-black focus:px-4 focus:py-2 focus:text-[12px] focus:tracking-[2px] focus:uppercase focus:font-bold"
         >
           Skip to main content
         </a>
@@ -228,7 +228,7 @@ export default function RootLayout({
           }}
         />
         <nav
-          className="fixed top-0 left-0 right-0 z-[60] backdrop-blur bg-[rgba(0,10,10,0.92)] border-b border-[rgba(0,229,229,0.12)]"
+          className="fixed top-0 left-0 right-0 z-[60] backdrop-blur bg-[rgba(0,10,10,0.92)] border-b border-terminal-border"
           aria-label="Main navigation"
         >
           <div className="mx-auto max-w-5xl px-6 py-4 flex items-center">

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -1,16 +1,12 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { JetBrains_Mono } from "next/font/google";
+import { NavLinks } from "./(components)/NavLinks";
 import "./globals.css";
-import Link from "next/link";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
   subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
+  weight: ["300", "400", "500", "700"],
 });
 
 export const metadata: Metadata = {
@@ -87,15 +83,25 @@ export default function RootLayout({
         <meta httpEquiv="X-Content-Type-Options" content="nosniff" />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${jetbrainsMono.variable} antialiased`}
       >
         <a
           href="#main-content"
-          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:bg-purple-600 focus:text-white focus:px-4 focus:py-2 focus:rounded focus:text-sm focus:font-medium"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-50 focus:bg-[#00e5e5] focus:text-black focus:px-4 focus:py-2 focus:text-[12px] focus:tracking-[2px] focus:uppercase focus:font-bold"
         >
           Skip to main content
         </a>
-        <div className="star-field" aria-hidden="true" />
+        <div
+          aria-hidden="true"
+          style={{
+            position: "fixed",
+            inset: 0,
+            pointerEvents: "none",
+            zIndex: 50,
+            background:
+              "repeating-linear-gradient(0deg, transparent, transparent 3px, rgba(0,200,200,0.008) 3px, rgba(0,200,200,0.008) 4px)",
+          }}
+        />
         {/* ProfilePage with Person schema */}
         <script
           type="application/ld+json"
@@ -222,23 +228,19 @@ export default function RootLayout({
           }}
         />
         <nav
-          className="fixed top-0 left-0 right-0 z-10 backdrop-blur bg-black/10 border-b border-white/10"
+          className="fixed top-0 left-0 right-0 z-[60] backdrop-blur bg-[rgba(0,10,10,0.92)] border-b border-[rgba(0,229,229,0.12)]"
           aria-label="Main navigation"
         >
-          <div className="mx-auto max-w-6xl px-4 py-3 flex items-center gap-6">
-            <Link href="/" className="text-white hover:opacity-80">Home</Link>
-            <Link href="/publications" className="text-white hover:opacity-80">Publications</Link>
-            <Link href="/resume" className="text-white hover:opacity-80">Resume/CV</Link>
-            <div className="ml-auto flex items-center gap-4">
-              <a href="https://www.linkedin.com/in/jeffb0llinger" target="_blank" rel="noopener noreferrer" className="text-white/70 hover:text-white hover:opacity-80 text-sm">LinkedIn</a>
-              <a href="https://github.com/jkeychan" target="_blank" rel="noopener noreferrer" className="text-white/70 hover:text-white hover:opacity-80 text-sm">GitHub</a>
-            </div>
+          <div className="mx-auto max-w-5xl px-6 py-4 flex items-center">
+            <NavLinks />
           </div>
         </nav>
         <div className="pt-16" id="main-content">{children}</div>
-        <footer className="mt-8 border-t border-white/10 text-white/60 text-sm">
-          <div className="mx-auto max-w-6xl px-4 py-6">
-            <p>&copy; Jeff Bollinger</p>
+        <footer className="mt-8 border-t border-[rgba(0,229,229,0.08)]">
+          <div className="mx-auto max-w-5xl px-6 py-6">
+            <p className="text-[11px] tracking-[2px] text-[rgba(0,229,229,0.2)]">
+              &copy; {new Date().getFullYear()} Jeff Bollinger
+            </p>
           </div>
         </footer>
       </body>

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -235,7 +235,7 @@ export default function RootLayout({
             <NavLinks />
           </div>
         </nav>
-        <div className="pt-16" id="main-content">{children}</div>
+        <div className="pt-16" id="main-content" tabIndex={-1}>{children}</div>
         <footer className="mt-8 border-t border-[rgba(0,229,229,0.08)]">
           <div className="mx-auto max-w-5xl px-6 py-6">
             <p className="text-[11px] tracking-[2px] text-[rgba(0,229,229,0.2)]">

--- a/site/src/app/not-found.tsx
+++ b/site/src/app/not-found.tsx
@@ -2,11 +2,11 @@ import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <main className="min-h-[70vh] flex flex-col items-center justify-center px-6 py-16 text-[#00e5e5] text-center">
-      <p className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-4">
+    <main className="min-h-[70vh] flex flex-col items-center justify-center px-6 py-16 text-terminal-cyan text-center">
+      <p className="text-[11px] tracking-[4px] uppercase text-terminal-cyan-35 mb-4">
         {"// not found"}
       </p>
-      <h1 className="text-[80px] font-bold tracking-tight text-[#00e5e5] [text-shadow:0_0_40px_rgba(0,229,229,0.3)] leading-none mb-4">
+      <h1 className="text-[80px] font-bold tracking-tight text-terminal-cyan [text-shadow:0_0_40px_rgba(0,229,229,0.3)] leading-none mb-4">
         404
       </h1>
       <p className="text-[13px] text-[rgba(0,229,229,0.5)] mb-10 max-w-md leading-[1.7]">
@@ -15,13 +15,13 @@ export default function NotFound() {
       <div className="flex gap-3">
         <Link
           href="/"
-          className="bg-[#00e5e5] text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5"
+          className="bg-terminal-cyan text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5"
         >
           Go Home
         </Link>
         <Link
           href="/publications"
-          className="bg-transparent text-[#00e5e5] text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+          className="bg-transparent text-terminal-cyan text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
         >
           Publications
         </Link>

--- a/site/src/app/not-found.tsx
+++ b/site/src/app/not-found.tsx
@@ -6,7 +6,10 @@ export default function NotFound() {
       <p className="text-[11px] tracking-[4px] uppercase text-terminal-cyan-35 mb-4">
         {"// not found"}
       </p>
-      <h1 className="text-[80px] font-bold tracking-tight text-terminal-cyan [text-shadow:0_0_40px_rgba(0,229,229,0.3)] leading-none mb-4">
+      <h1
+        aria-label="Page Not Found"
+        className="text-[80px] font-bold tracking-tight text-terminal-cyan [text-shadow:0_0_40px_rgba(0,229,229,0.3)] leading-none mb-4"
+      >
         404
       </h1>
       <p className="text-[13px] text-[rgba(0,229,229,0.5)] mb-10 max-w-md leading-[1.7]">
@@ -21,7 +24,7 @@ export default function NotFound() {
         </Link>
         <Link
           href="/publications"
-          className="bg-transparent text-terminal-cyan text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+          className="bg-transparent text-terminal-cyan text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)] transition-colors"
         >
           Publications
         </Link>

--- a/site/src/app/not-found.tsx
+++ b/site/src/app/not-found.tsx
@@ -2,22 +2,26 @@ import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <main className="min-h-[70vh] flex flex-col items-center justify-center p-8 text-white text-center">
-      <h1 className="text-6xl font-extrabold text-purple-400 mb-4">404</h1>
-      <h2 className="text-2xl font-semibold mb-2">Page not found</h2>
-      <p className="text-white/70 mb-8 max-w-md">
+    <main className="min-h-[70vh] flex flex-col items-center justify-center px-6 py-16 text-[#00e5e5] text-center">
+      <p className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-4">
+        {"// not found"}
+      </p>
+      <h1 className="text-[80px] font-bold tracking-tight text-[#00e5e5] [text-shadow:0_0_40px_rgba(0,229,229,0.3)] leading-none mb-4">
+        404
+      </h1>
+      <p className="text-[13px] text-[rgba(0,229,229,0.5)] mb-10 max-w-md leading-[1.7]">
         The page you are looking for does not exist or may have been moved.
       </p>
-      <div className="flex gap-4">
+      <div className="flex gap-3">
         <Link
           href="/"
-          className="inline-flex items-center gap-2 bg-purple-600 hover:bg-purple-500 text-white text-sm font-medium px-4 py-2 rounded"
+          className="bg-[#00e5e5] text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5"
         >
           Go Home
         </Link>
         <Link
           href="/publications"
-          className="inline-flex items-center gap-2 bg-white/5 hover:bg-white/10 text-white text-sm font-medium px-4 py-2 rounded border border-white/10"
+          className="bg-transparent text-[#00e5e5] text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
         >
           Publications
         </Link>

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -134,7 +134,7 @@ export default function Home() {
               width={160}
               height={160}
               priority
-              className="w-36 h-36 md:w-40 md:h-40 border border-terminal-border-hv [box-shadow:0_0_30px_rgba(0,229,229,0.08)] [filter:saturate(0.5)_contrast(1.1)]"
+              className="card-pulse w-36 h-36 md:w-40 md:h-40 border-2 border-[rgba(0,229,229,0.3)] [filter:saturate(0.5)_contrast(1.1)]"
             />
           </div>
         </section>

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -1,6 +1,5 @@
 import Image from "next/image";
 import Link from "next/link";
-import { TypewriterText } from "./(components)/TypewriterText";
 import { ProjectCard } from "./(components)/ProjectCard";
 
 export default function Home() {
@@ -81,102 +80,91 @@ export default function Home() {
           }),
         }}
       />
-      <main className="min-h-[80vh] p-6 md:p-8 text-white">
-        <section className="mx-auto max-w-5xl grid grid-cols-1 md:grid-cols-2 gap-6 items-start">
+      <main className="min-h-[80vh] px-6 md:px-8 pt-8 pb-16 text-[#00e5e5]">
+        {/* Hero */}
+        <section className="mx-auto max-w-5xl grid grid-cols-1 md:grid-cols-[1fr_auto] gap-14 items-start mb-16 pb-16 border-b border-[rgba(0,229,229,0.1)]">
           <div>
-            <h1 className="text-3xl md:text-5xl font-extrabold leading-tight mb-1">
-              Hello I&apos;m <span className="text-purple-400">Jeff Bollinger</span>
-            </h1>
-          </div>
-          <div className="mt-1 flex items-start gap-4">
-            <Image
-              src="/static/media/avatar.d355c64ac071e83edeabfc9c51f454d3.svg"
-              alt="Jeff Bollinger headshot"
-              width={128}
-              height={128}
-              priority
-              className="w-28 h-28 md:w-32 md:h-32 rounded-full border border-white/20 shadow-sm"
-            />
-            <div className="min-h-[160px] md:min-h-[120px] flex-1">
-              <TypewriterText
-                className="text-purple-300 text-lg md:text-2xl mb-3 block"
-                phrases={[
-                  "Infosec Professional | 25 years",
-                  "Threat Detection | Incident Response",
-                  "Detection Engineering | Security Architecture",
-                  "Executive Leadership | Mentoring, Team Building",
-                ]}
+            <p className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-4">
+              {"// security author & leader"}
+            </p>
+            <h1 className="text-[40px] md:text-[60px] font-bold tracking-tight text-[#00e5e5] [text-shadow:0_0_40px_rgba(0,229,229,0.3)] leading-none mb-5">
+              Jeff<br />Bollinger
+              <span
+                aria-hidden="true"
+                className="cursor-blink inline-block w-[4px] h-[50px] md:h-[62px] bg-[#00e5e5] align-middle ml-2 [box-shadow:0_0_10px_rgba(0,229,229,0.8)]"
               />
-              <p className="text-white/80 text-sm md:text-base mt-2 mb-4">
-                Jeff Bollinger is a cybersecurity leader focused on incident response, detection engineering, and
-                large-scale security operations. He has led programs at LinkedIn and Cisco and frequently writes and
-                speaks about security monitoring, threat detection, and response.
-              </p>
+            </h1>
+            <p className="text-[13px] md:text-[14px] text-[rgba(0,229,229,0.6)] leading-[1.7] max-w-[440px] mb-8">
+              Author of <em>Crafting the Infosec Playbook</em>. Writing and speaking
+              on security operations, threat hunting, and incident response.
+            </p>
+            <div className="flex gap-3">
+              <Link
+                href="/publications"
+                className="bg-[#00e5e5] text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5"
+              >
+                Publications
+              </Link>
+              <Link
+                href="/resume"
+                className="bg-transparent text-[#00e5e5] text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+              >
+                Resume / CV
+              </Link>
             </div>
           </div>
-          <div className="md:col-span-2 flex flex-wrap gap-3">
-            <Link
-              href="/publications"
-              className="inline-flex items-center gap-2 bg-purple-600 hover:bg-purple-500 text-white text-sm font-medium px-4 py-2 rounded"
-            >
-              View Publications
-            </Link>
-            <Link
-              href="/resume"
-              className="inline-flex items-center gap-2 bg-white/5 hover:bg-white/10 text-white text-sm font-medium px-4 py-2 rounded border border-white/10"
-            >
-              Resume / CV
-            </Link>
-            <a
-              href="https://www.linkedin.com/in/jeffb0llinger/"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-2 bg-white/5 hover:bg-white/10 text-white text-sm font-medium px-4 py-2 rounded border border-white/10"
-            >
-              LinkedIn
-            </a>
+          <div>
+            <Image
+              src="/static/media/avatar.d355c64ac071e83edeabfc9c51f454d3.svg"
+              alt="Jeff Bollinger"
+              width={160}
+              height={160}
+              priority
+              className="w-36 h-36 md:w-40 md:h-40 border border-[rgba(0,229,229,0.25)] [box-shadow:0_0_30px_rgba(0,229,229,0.08)] [filter:saturate(0.5)_contrast(1.1)]"
+            />
           </div>
         </section>
 
-        <section className="mx-auto max-w-5xl mt-8 grid grid-cols-1 lg:grid-cols-3 gap-6 items-stretch">
-          <div className="rounded-lg border border-white/10 bg-white/5 p-4">
-            <h2 className="text-white/90 font-semibold mb-2">What I do</h2>
-            <ul className="list-disc pl-5 text-white/80 space-y-1 text-sm">
-              <li>Build, modernize, and lead detection engineering, incident response, and insider threat programs</li>
-              <li>Design reliable security architecture and observability for large enterprises</li>
-              <li>Coach and mentor high-performing security teams</li>
-              <li>Build and lead security operations centers</li>
-              <li>Lead security architecture and design</li>
-              <li>Lead security operations and incident response</li>
-            </ul>
+        {/* About block */}
+        <div className="mx-auto max-w-5xl mb-8">
+          <div className="relative border border-[rgba(0,229,229,0.15)] bg-[rgba(0,229,229,0.02)] px-7 py-5">
+            <span className="absolute -top-[9px] left-4 bg-[#000a0a] px-2 text-[10px] tracking-[3px] uppercase text-[rgba(0,229,229,0.4)]">
+              about
+            </span>
+            <p className="text-[13px] text-[rgba(0,229,229,0.65)] leading-[1.8]">
+              Cybersecurity leader focused on building and running security operations
+              programs. Detection engineering, incident response, security
+              architecture, and growing high-performing teams.
+            </p>
           </div>
-          <div className="rounded-lg border border-white/10 bg-white/5 p-4">
-            <h2 className="text-white/90 font-semibold mb-2">Core skills</h2>
-            <div className="flex flex-wrap gap-2 text-sm">
-              <span className="px-2 py-1 rounded bg-purple-600/30 border border-purple-300/20">Threat Detection</span>
-              <span className="px-2 py-1 rounded bg-purple-600/30 border border-purple-300/20">Incident Response</span>
-              <span className="px-2 py-1 rounded bg-purple-600/30 border border-purple-300/20">Detection Engineering</span>
-              <span className="px-2 py-1 rounded bg-purple-600/30 border border-purple-300/20">Security Architecture</span>
-              <span className="px-2 py-1 rounded bg-purple-600/30 border border-purple-300/20">Executive Leadership</span>
-              <span className="px-2 py-1 rounded bg-purple-600/30 border border-purple-300/20">Security Operations</span>
-              <span className="px-2 py-1 rounded bg-purple-600/30 border border-purple-300/20">Security Engineering</span>
-            </div>
-          </div>
-          <div className="relative rounded-lg border border-white/10 bg-white/5 overflow-hidden h-full">
-            <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(167,139,250,0.18),transparent_60%)]" />
-            <Image
-              src="/static/media/home-main.bb0187d03cff74c7d9bec63d61173238.svg"
-              alt="Home Illustration"
-              fill
-              priority
-              sizes="(max-width: 1024px) 100vw, 33vw"
-              className="object-cover"
-            />
-          </div>
-        </section>
-        <section className="mx-auto max-w-5xl mt-10">
-          <h2 className="text-2xl font-semibold text-purple-400 mb-4">Recent highlights</h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        </div>
+
+        {/* Skills */}
+        <div className="mx-auto max-w-5xl flex flex-wrap gap-2 mb-16">
+          {[
+            "Threat Detection",
+            "Incident Response",
+            "Detection Engineering",
+            "Security Architecture",
+            "Executive Leadership",
+            "Security Operations",
+            "Security Engineering",
+          ].map((skill) => (
+            <span
+              key={skill}
+              className="text-[11px] tracking-[1.5px] uppercase border border-[rgba(0,229,229,0.15)] bg-[rgba(0,229,229,0.03)] px-3 py-1.5 text-[rgba(0,229,229,0.5)]"
+            >
+              {skill}
+            </span>
+          ))}
+        </div>
+
+        {/* Recent highlights */}
+        <section className="mx-auto max-w-5xl">
+          <h2 className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-6 pb-3 border-b border-[rgba(0,229,229,0.08)]">
+            {"// recent highlights"}
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             <ProjectCard
               imageSrc="/static/media/cover-blue-edition.0781c7b04869f677781b.png"
               title="Crafting the Infosec Playbook"

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -80,34 +80,34 @@ export default function Home() {
           }),
         }}
       />
-      <main className="min-h-[80vh] px-6 md:px-8 pt-8 pb-16 text-[#00e5e5]">
+      <main className="min-h-[80vh] px-6 md:px-8 pt-8 pb-16 text-terminal-cyan">
         {/* Hero */}
         <section className="mx-auto max-w-5xl grid grid-cols-1 md:grid-cols-[1fr_auto] gap-14 items-start mb-16 pb-16 border-b border-[rgba(0,229,229,0.1)]">
           <div>
-            <p className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-4">
+            <p className="text-[11px] tracking-[4px] uppercase text-terminal-cyan-35 mb-4">
               {"// security author & leader"}
             </p>
-            <h1 className="text-[40px] md:text-[60px] font-bold tracking-tight text-[#00e5e5] [text-shadow:0_0_40px_rgba(0,229,229,0.3)] leading-none mb-5">
+            <h1 className="text-[40px] md:text-[60px] font-bold tracking-tight text-terminal-cyan [text-shadow:0_0_40px_rgba(0,229,229,0.3)] leading-none mb-5">
               Jeff<br />Bollinger
               <span
                 aria-hidden="true"
-                className="cursor-blink inline-block w-[4px] h-[50px] md:h-[62px] bg-[#00e5e5] align-middle ml-2 [box-shadow:0_0_10px_rgba(0,229,229,0.8)]"
+                className="cursor-blink inline-block w-[4px] h-[50px] md:h-[62px] bg-terminal-cyan align-middle ml-2 [box-shadow:0_0_10px_rgba(0,229,229,0.8)]"
               />
             </h1>
-            <p className="text-[13px] md:text-[14px] text-[rgba(0,229,229,0.6)] leading-[1.7] max-w-[440px] mb-8">
+            <p className="text-[13px] md:text-[14px] text-terminal-cyan-60 leading-[1.7] max-w-[440px] mb-8">
               Author of <em>Crafting the Infosec Playbook</em>. Writing and speaking
               on security operations, threat hunting, and incident response.
             </p>
             <div className="flex gap-3">
               <Link
                 href="/publications"
-                className="bg-[#00e5e5] text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5"
+                className="bg-terminal-cyan text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5"
               >
                 Publications
               </Link>
               <Link
                 href="/resume"
-                className="bg-transparent text-[#00e5e5] text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+                className="bg-transparent text-terminal-cyan text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
               >
                 Resume / CV
               </Link>
@@ -120,15 +120,15 @@ export default function Home() {
               width={160}
               height={160}
               priority
-              className="w-36 h-36 md:w-40 md:h-40 border border-[rgba(0,229,229,0.25)] [box-shadow:0_0_30px_rgba(0,229,229,0.08)] [filter:saturate(0.5)_contrast(1.1)]"
+              className="w-36 h-36 md:w-40 md:h-40 border border-terminal-border-hv [box-shadow:0_0_30px_rgba(0,229,229,0.08)] [filter:saturate(0.5)_contrast(1.1)]"
             />
           </div>
         </section>
 
         {/* About block */}
         <div className="mx-auto max-w-5xl mb-8">
-          <div className="relative border border-[rgba(0,229,229,0.15)] bg-[rgba(0,229,229,0.02)] px-7 py-5">
-            <span className="absolute -top-[9px] left-4 bg-[#000a0a] px-2 text-[10px] tracking-[3px] uppercase text-[rgba(0,229,229,0.4)]">
+          <div className="relative border border-[rgba(0,229,229,0.15)] bg-terminal-surface px-7 py-5">
+            <span className="absolute -top-[9px] left-4 bg-terminal-bg px-2 text-[10px] tracking-[3px] uppercase text-[rgba(0,229,229,0.4)]">
               about
             </span>
             <p className="text-[13px] text-[rgba(0,229,229,0.65)] leading-[1.8]">
@@ -161,7 +161,7 @@ export default function Home() {
 
         {/* Recent highlights */}
         <section className="mx-auto max-w-5xl">
-          <h2 className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-6 pb-3 border-b border-[rgba(0,229,229,0.08)]">
+          <h2 className="text-[11px] tracking-[4px] uppercase text-terminal-cyan-35 mb-6 pb-3 border-b border-[rgba(0,229,229,0.08)]">
             {"// recent highlights"}
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { TypewriterText } from "./(components)/TypewriterText";
 import { ProjectCard } from "./(components)/ProjectCard";
 
 export default function Home() {
@@ -87,13 +88,26 @@ export default function Home() {
             <p className="text-[11px] tracking-[4px] uppercase text-terminal-cyan-35 mb-4">
               {"// security author & leader"}
             </p>
-            <h1 className="text-[40px] md:text-[60px] font-bold tracking-tight text-terminal-cyan [text-shadow:0_0_40px_rgba(0,229,229,0.3)] leading-none mb-5">
+            <h1 className="text-[40px] md:text-[60px] font-bold tracking-tight text-terminal-cyan [text-shadow:0_0_40px_rgba(0,229,229,0.3)] leading-none mb-3">
               Jeff<br />Bollinger
               <span
                 aria-hidden="true"
                 className="cursor-blink inline-block w-[4px] h-[50px] md:h-[62px] bg-terminal-cyan align-middle ml-2 [box-shadow:0_0_10px_rgba(0,229,229,0.8)]"
               />
             </h1>
+            <TypewriterText
+              className="text-[12px] tracking-[3px] uppercase text-terminal-cyan-35 mb-5"
+              phrases={[
+                "Threat Detection + Incident Response",
+                "Detection Engineering + Security Architecture",
+                "Executive Leadership + Team Building",
+                "Security Author + International Speaker",
+              ]}
+              typingMsPerChar={40}
+              deletingMsPerChar={20}
+              holdBeforeDeleteMs={1800}
+              holdBeforeNextMs={400}
+            />
             <p className="text-[13px] md:text-[14px] text-terminal-cyan-60 leading-[1.7] max-w-[440px] mb-8">
               Author of <em>Crafting the Infosec Playbook</em>. Writing and speaking
               on security operations, threat hunting, and incident response.

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -121,7 +121,7 @@ export default function Home() {
               </Link>
               <Link
                 href="/resume"
-                className="bg-transparent text-terminal-cyan text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+                className="bg-transparent text-terminal-cyan text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)] transition-colors"
               >
                 Resume / CV
               </Link>

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -199,6 +199,14 @@ export default function Home() {
               linkHref="https://cloud.withgoogle.com/cloudsecurity/podcast/ep96-cloud-security-observability-for-detection-and-response/"
             />
           </div>
+          <div className="mt-8 pt-6 border-t border-[rgba(0,229,229,0.08)]">
+            <Link
+              href="/publications"
+              className="text-[11px] tracking-[3px] uppercase text-terminal-cyan-35 hover:text-terminal-cyan transition-colors"
+            >
+              View all publications &rarr;
+            </Link>
+          </div>
         </section>
       </main>
     </>

--- a/site/src/app/publications/page.tsx
+++ b/site/src/app/publications/page.tsx
@@ -76,26 +76,35 @@ export default function PublicationsPage() {
           }),
         }}
       />
-      <main className="min-h-screen p-8 text-white">
-        <h1 className="text-3xl font-bold mb-2">
-          <span className="text-purple-400">
-            Publications and Conferences
-          </span>
-        </h1>
-        <p className="text-white/80 mb-6">
-          This is a non-exhaustive list of blogs, podcasts, articles,
-          reviews, conferences hosted, and other publications I&apos;ve
-          created, co-created, or been involved in.
-        </p>
+      <main className="min-h-screen px-6 md:px-8 pt-8 pb-16 text-[#00e5e5]">
+        {/* Page header */}
+        <div className="mx-auto max-w-5xl mb-12">
+          <p className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-4">
+            {"// writing, talks & appearances"}
+          </p>
+          <h1 className="text-[40px] font-bold tracking-tight text-[#00e5e5] [text-shadow:0_0_30px_rgba(0,229,229,0.2)] leading-none mb-4">
+            Publications
+            <span className="text-[10px] tracking-[2px] border border-[rgba(0,229,229,0.15)] px-2.5 py-1 ml-4 align-middle font-normal">
+              {publications.length}
+            </span>
+          </h1>
+          <p className="text-[13px] text-[rgba(0,229,229,0.5)] leading-[1.7] max-w-[560px]">
+            A non-exhaustive collection of blogs, podcasts, articles, conference
+            talks, and other publications I&apos;ve created, co-created, or been
+            involved in.
+          </p>
+        </div>
 
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {/* Grid */}
+        <div className="mx-auto max-w-5xl grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
           {visibleItems.map((p) => (
             <ProjectCard key={p.title} {...p} />
           ))}
         </div>
 
+        {/* Load more */}
         {visibleCount < publications.length && (
-          <div className="mt-8 flex justify-center">
+          <div className="mx-auto max-w-5xl mt-12 pt-6 border-t border-[rgba(0,229,229,0.08)] flex items-center gap-6">
             <button
               onClick={() =>
                 setVisibleCount((prev) =>
@@ -103,10 +112,13 @@ export default function PublicationsPage() {
                 )
               }
               aria-label="Load more publications"
-              className="px-4 py-2 rounded bg-purple-600 hover:bg-purple-500 text-white text-sm font-medium"
+              className="bg-transparent text-[#00e5e5] text-[11px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
             >
               Load more
             </button>
+            <span className="text-[11px] text-[rgba(0,229,229,0.25)] tracking-[1px]">
+              Showing {Math.min(visibleCount, publications.length)} of {publications.length}
+            </span>
           </div>
         )}
 

--- a/site/src/app/publications/page.tsx
+++ b/site/src/app/publications/page.tsx
@@ -5,6 +5,8 @@ import { ProjectCard } from "../(components)/ProjectCard";
 import { publications } from "./data";
 import { generateSchemas } from "@/lib/schema";
 
+const { itemList, schemas } = generateSchemas(publications);
+
 export default function PublicationsPage() {
   const [visibleCount, setVisibleCount] = useState(12);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
@@ -31,7 +33,6 @@ export default function PublicationsPage() {
     0,
     Math.min(visibleCount, publications.length),
   );
-  const { itemList, schemas } = generateSchemas(publications);
 
   return (
     <>
@@ -84,7 +85,10 @@ export default function PublicationsPage() {
           </p>
           <h1 className="text-[40px] font-bold tracking-tight text-terminal-cyan [text-shadow:0_0_30px_rgba(0,229,229,0.2)] leading-none mb-4">
             Publications
-            <span className="text-[10px] tracking-[2px] border border-[rgba(0,229,229,0.15)] px-2.5 py-1 ml-4 align-middle font-normal">
+            <span
+              className="text-[10px] tracking-[2px] border border-[rgba(0,229,229,0.15)] px-2.5 py-1 ml-4 align-middle font-normal"
+              aria-label={`${publications.length} publications`}
+            >
               {publications.length}
             </span>
           </h1>
@@ -112,7 +116,7 @@ export default function PublicationsPage() {
                 )
               }
               aria-label="Load more publications"
-              className="bg-transparent text-terminal-cyan text-[11px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+              className="bg-transparent text-terminal-cyan text-[11px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)] transition-colors"
             >
               Load more
             </button>

--- a/site/src/app/publications/page.tsx
+++ b/site/src/app/publications/page.tsx
@@ -102,17 +102,15 @@ export default function PublicationsPage() {
           </p>
         </div>
 
-        {/* Terminal extraction animation */}
-        {!terminalDone && (
-          <div className="mx-auto max-w-5xl">
-            <PublicationsTerminal
-              total={publications.length}
-              onDone={handleTerminalDone}
-            />
-          </div>
-        )}
+        {/* Terminal extraction animation — stays visible */}
+        <div className="mx-auto max-w-5xl">
+          <PublicationsTerminal
+            total={publications.length}
+            onDone={handleTerminalDone}
+          />
+        </div>
 
-        {/* Grid — staggered fade-in after terminal */}
+        {/* Grid — staggered fade-in after terminal completes */}
         {terminalDone && (
           <div className="mx-auto max-w-5xl grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
             {visibleItems.map((p, i) => (

--- a/site/src/app/publications/page.tsx
+++ b/site/src/app/publications/page.tsx
@@ -76,13 +76,13 @@ export default function PublicationsPage() {
           }),
         }}
       />
-      <main className="min-h-screen px-6 md:px-8 pt-8 pb-16 text-[#00e5e5]">
+      <main className="min-h-screen px-6 md:px-8 pt-8 pb-16 text-terminal-cyan">
         {/* Page header */}
         <div className="mx-auto max-w-5xl mb-12">
-          <p className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-4">
+          <p className="text-[11px] tracking-[4px] uppercase text-terminal-cyan-35 mb-4">
             {"// writing, talks & appearances"}
           </p>
-          <h1 className="text-[40px] font-bold tracking-tight text-[#00e5e5] [text-shadow:0_0_30px_rgba(0,229,229,0.2)] leading-none mb-4">
+          <h1 className="text-[40px] font-bold tracking-tight text-terminal-cyan [text-shadow:0_0_30px_rgba(0,229,229,0.2)] leading-none mb-4">
             Publications
             <span className="text-[10px] tracking-[2px] border border-[rgba(0,229,229,0.15)] px-2.5 py-1 ml-4 align-middle font-normal">
               {publications.length}
@@ -112,7 +112,7 @@ export default function PublicationsPage() {
                 )
               }
               aria-label="Load more publications"
-              className="bg-transparent text-[#00e5e5] text-[11px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+              className="bg-transparent text-terminal-cyan text-[11px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
             >
               Load more
             </button>

--- a/site/src/app/publications/page.tsx
+++ b/site/src/app/publications/page.tsx
@@ -1,15 +1,18 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { ProjectCard } from "../(components)/ProjectCard";
+import { PublicationsTerminal } from "../(components)/PublicationsTerminal";
 import { publications } from "./data";
 import { generateSchemas } from "@/lib/schema";
 
 const { itemList, schemas } = generateSchemas(publications);
 
 export default function PublicationsPage() {
+  const [terminalDone, setTerminalDone] = useState(false);
   const [visibleCount, setVisibleCount] = useState(12);
   const sentinelRef = useRef<HTMLDivElement | null>(null);
+  const handleTerminalDone = useCallback(() => setTerminalDone(true), []);
 
   useEffect(() => {
     const el = sentinelRef.current;
@@ -99,12 +102,30 @@ export default function PublicationsPage() {
           </p>
         </div>
 
-        {/* Grid */}
-        <div className="mx-auto max-w-5xl grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {visibleItems.map((p) => (
-            <ProjectCard key={p.title} {...p} />
-          ))}
-        </div>
+        {/* Terminal extraction animation */}
+        {!terminalDone && (
+          <div className="mx-auto max-w-5xl">
+            <PublicationsTerminal
+              total={publications.length}
+              onDone={handleTerminalDone}
+            />
+          </div>
+        )}
+
+        {/* Grid — staggered fade-in after terminal */}
+        {terminalDone && (
+          <div className="mx-auto max-w-5xl grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {visibleItems.map((p, i) => (
+              <div
+                key={p.title}
+                className="opacity-0 animate-fade-in"
+                style={{ animationDelay: `${i * 60}ms`, animationFillMode: "forwards" }}
+              >
+                <ProjectCard {...p} />
+              </div>
+            ))}
+          </div>
+        )}
 
         {/* Load more */}
         {visibleCount < publications.length && (

--- a/site/src/app/resume/page.tsx
+++ b/site/src/app/resume/page.tsx
@@ -51,7 +51,7 @@ export default function ResumePage() {
               View PDF
             </a>
             <a
-              className="bg-transparent text-terminal-cyan text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+              className="bg-transparent text-terminal-cyan text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)] transition-colors"
               href="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.docx"
               target="_blank"
               rel="noopener noreferrer"
@@ -64,7 +64,19 @@ export default function ResumePage() {
               title="Jeff Bollinger Resume"
               src="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.pdf"
               className="w-full h-full"
-            />
+            >
+              <p className="text-[12px] text-terminal-cyan-35 p-4">
+                PDF preview unavailable.{" "}
+                <a
+                  href="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.pdf"
+                  className="text-terminal-cyan underline"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  Download PDF directly
+                </a>
+              </p>
+            </iframe>
           </div>
         </div>
       </main>

--- a/site/src/app/resume/page.tsx
+++ b/site/src/app/resume/page.tsx
@@ -33,17 +33,17 @@ export default function ResumePage() {
           }),
         }}
       />
-      <main className="min-h-screen px-6 md:px-8 pt-8 pb-16 text-[#00e5e5]">
+      <main className="min-h-screen px-6 md:px-8 pt-8 pb-16 text-terminal-cyan">
         <div className="mx-auto max-w-5xl mb-8">
-          <p className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-4">
+          <p className="text-[11px] tracking-[4px] uppercase text-terminal-cyan-35 mb-4">
             {"// resume & cv"}
           </p>
-          <h1 className="text-[40px] font-bold tracking-tight text-[#00e5e5] [text-shadow:0_0_30px_rgba(0,229,229,0.2)] leading-none mb-8">
+          <h1 className="text-[40px] font-bold tracking-tight text-terminal-cyan [text-shadow:0_0_30px_rgba(0,229,229,0.2)] leading-none mb-8">
             Resume / CV
           </h1>
           <div className="flex gap-3 mb-8">
             <a
-              className="bg-[#00e5e5] text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5"
+              className="bg-terminal-cyan text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5"
               href="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.pdf"
               target="_blank"
               rel="noopener noreferrer"
@@ -51,7 +51,7 @@ export default function ResumePage() {
               View PDF
             </a>
             <a
-              className="bg-transparent text-[#00e5e5] text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+              className="bg-transparent text-terminal-cyan text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
               href="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.docx"
               target="_blank"
               rel="noopener noreferrer"

--- a/site/src/app/resume/page.tsx
+++ b/site/src/app/resume/page.tsx
@@ -33,32 +33,39 @@ export default function ResumePage() {
           }),
         }}
       />
-      <main className="min-h-screen p-8 text-white">
-        <h1 className="text-3xl font-bold mb-6">Resume / CV</h1>
-        <div className="flex gap-4 mb-6">
-          <a
-            className="inline-flex items-center gap-2 bg-purple-600 hover:bg-purple-500 text-white text-sm font-medium px-3 py-2 rounded"
-            href="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            View PDF
-          </a>
-          <a
-            className="inline-flex items-center gap-2 bg-white/5 hover:bg-white/10 text-white text-sm font-medium px-3 py-2 rounded border border-white/10"
-            href="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.docx"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Download DOCX
-          </a>
-        </div>
-        <div className="bg-white rounded overflow-hidden h-[80vh]">
-          <iframe
-            title="Jeff Bollinger Resume"
-            src="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.pdf"
-            className="w-full h-full"
-          />
+      <main className="min-h-screen px-6 md:px-8 pt-8 pb-16 text-[#00e5e5]">
+        <div className="mx-auto max-w-5xl mb-8">
+          <p className="text-[11px] tracking-[4px] uppercase text-[rgba(0,229,229,0.35)] mb-4">
+            {"// resume & cv"}
+          </p>
+          <h1 className="text-[40px] font-bold tracking-tight text-[#00e5e5] [text-shadow:0_0_30px_rgba(0,229,229,0.2)] leading-none mb-8">
+            Resume / CV
+          </h1>
+          <div className="flex gap-3 mb-8">
+            <a
+              className="bg-[#00e5e5] text-black font-bold text-[12px] tracking-[2px] uppercase px-5 py-2.5"
+              href="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.pdf"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              View PDF
+            </a>
+            <a
+              className="bg-transparent text-[#00e5e5] text-[12px] tracking-[2px] uppercase px-5 py-2.5 border border-[rgba(0,229,229,0.3)] hover:border-[rgba(0,229,229,0.5)]"
+              href="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.docx"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Download DOCX
+            </a>
+          </div>
+          <div className="border border-[rgba(0,229,229,0.15)] overflow-hidden h-[80vh]">
+            <iframe
+              title="Jeff Bollinger Resume"
+              src="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.pdf"
+              className="w-full h-full"
+            />
+          </div>
         </div>
       </main>
     </>

--- a/site/src/app/resume/page.tsx
+++ b/site/src/app/resume/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { ResumeViewer } from "../(components)/ResumeViewer";
 
 export const metadata: Metadata = {
   title: "Resume / CV",
@@ -60,23 +61,7 @@ export default function ResumePage() {
             </a>
           </div>
           <div className="border border-[rgba(0,229,229,0.15)] overflow-hidden h-[80vh]">
-            <iframe
-              title="Jeff Bollinger Resume"
-              src="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.pdf"
-              className="w-full h-full"
-            >
-              <p className="text-[12px] text-terminal-cyan-35 p-4">
-                PDF preview unavailable.{" "}
-                <a
-                  href="/static/media/Jeff_Bollinger-Resume-2023-redacted.31d6cfe0d16ae931b73c.pdf"
-                  className="text-terminal-cyan underline"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Download PDF directly
-                </a>
-              </p>
-            </iframe>
+            <ResumeViewer />
           </div>
         </div>
       </main>


### PR DESCRIPTION
## Summary

- Replace purple/space-field theme with a terminal-inspired cyan phosphor aesthetic (JetBrains Mono, `#000a0a` background, `#00e5e5` cyan)
- Define a semantic Tailwind v4 token system (`terminal-cyan`, `terminal-bg`, `terminal-border`, `terminal-surface`, etc.) in `globals.css` `@theme inline` block — eliminates hardcoded hex values across all components
- Refactor nav into a `NavLinks` client component using `usePathname()` for active state highlighting; external links (LinkedIn, GitHub) pushed to the right
- Redesign homepage hero: two-column grid, blinking cursor, floating "about" block with inset label, skill tag row
- Redesign publications page: bold h1 with count badge, terminal card grid, load-more with "Showing X of Y" counter
- Update resume, 404, and ProjectCard with consistent terminal styling; scanline overlay added to layout
- Full build + lint + TSC passes clean; dev server visual inspection completed on all pages
- All Schema.org structured data preserved throughout

## Test plan

- [ ] CI build passes (`npm ci && npm run build`)
- [ ] No ESLint errors (`npm run lint`)
- [ ] No TypeScript errors (`npx tsc --noEmit`)
- [ ] Visual check: homepage, publications, resume, 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)