### PR TITLE
fix: resolve Google Search Console index errors

### DIFF
--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
+  trailingSlash: true,
   images: { unoptimized: true },
 };
 

--- a/site/src/app/project/page.tsx
+++ b/site/src/app/project/page.tsx
@@ -1,4 +1,12 @@
 import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+  alternates: {
+    canonical: "https://www.jeff-bollinger.com/publications",
+  },
+};
 
 export default function ProjectPage() {
   redirect("/publications");


### PR DESCRIPTION
## Summary
- Add `trailingSlash: true` to `next.config.ts` so `/resume/` and `/project/` no longer return 404 (GitHub Pages serves `dir/index.html` correctly)
- Add `noindex` robots meta and canonical pointing to `/publications` on the `/project` redirect page to clear the "page with redirect" and "crawled - currently not indexed" Search Console errors

## Test plan
- [ ] Verify `/resume/` and `/resume` both load after deploy
- [ ] Verify `/project/` and `/project` redirect to `/publications`
- [ ] Check `out/` build output contains directory structure (`resume/index.html`, `project/index.html`) instead of flat `.html` files
- [ ] Submit affected URLs in Google Search Console for re-crawl

🤖 Generated with [Claude Code](https://claude.com/claude-code)