### PR TITLE
fix: block /_next/ in robots.txt to prevent crawling of build assets

### DIFF
--- a/site/public/robots.txt
+++ b/site/public/robots.txt
@@ -6,4 +6,5 @@ Disallow: /
 
 User-agent: *
 Allow: /
+Disallow: /_next/
 Sitemap: https://www.jeff-bollinger.com/sitemap.xml


### PR DESCRIPTION
## Summary
- Add `Disallow: /_next/` for all user agents in `robots.txt`
- Prevents Google (and others) from crawling font files, JS chunks, and CSS from the Next.js build output, which was causing "Crawled - currently not indexed" errors in Search Console

## Test plan
- [ ] Verify `robots.txt` on live site includes the new disallow rule
- [ ] After deploy, submit affected `/_next/` URLs in Search Console to remove them from index

🤖 Generated with [Claude Code](https://claude.com/claude-code)