### PR TITLE
fix: align sitemap and canonical URLs with trailingSlash config

### DIFF
--- a/site/public/sitemap.xml
+++ b/site/public/sitemap.xml
@@ -15,24 +15,16 @@
 
   <!-- Publications page -->
   <url>
-    <loc>https://www.jeff-bollinger.com/publications</loc>
-    <lastmod>2025-08-13T00:00:00+00:00</lastmod>
+    <loc>https://www.jeff-bollinger.com/publications/</loc>
+    <lastmod>2026-03-24T00:00:00+00:00</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
 
-  <!-- Excluded: legacy project URL is redirected to /publications -->
-  <!-- <url>
-    <loc>https://www.jeff-bollinger.com/project</loc>
-    <lastmod>2025-08-13T00:00:00+00:00</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.2</priority>
-  </url> -->
-
   <!-- Resume page -->
   <url>
-    <loc>https://www.jeff-bollinger.com/resume</loc>
-    <lastmod>2025-08-13T00:00:00+00:00</lastmod>
+    <loc>https://www.jeff-bollinger.com/resume/</loc>
+    <lastmod>2026-03-24T00:00:00+00:00</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/site/src/app/publications/layout.tsx
+++ b/site/src/app/publications/layout.tsx
@@ -4,7 +4,7 @@ export const metadata: Metadata = {
   title: "Publications and Conferences",
   description:
     "Non-exhaustive list of Jeff Bollinger's blogs, articles, conferences hosted, and other publications.",
-  alternates: { canonical: "/publications" },
+  alternates: { canonical: "/publications/" },
 };
 
 export default function PublicationsLayout({

--- a/site/src/app/publications/page.tsx
+++ b/site/src/app/publications/page.tsx
@@ -74,7 +74,7 @@ export default function PublicationsPage() {
                 "@type": "ListItem",
                 position: 2,
                 name: "Publications",
-                item: "https://www.jeff-bollinger.com/publications",
+                item: "https://www.jeff-bollinger.com/publications/",
               },
             ],
           }),

--- a/site/src/app/resume/page.tsx
+++ b/site/src/app/resume/page.tsx
@@ -4,7 +4,7 @@ import { ResumeViewer } from "../(components)/ResumeViewer";
 export const metadata: Metadata = {
   title: "Resume / CV",
   description: "Resume and CV for Jeff Bollinger.",
-  alternates: { canonical: "/resume" },
+  alternates: { canonical: "/resume/" },
 };
 
 export default function ResumePage() {
@@ -28,7 +28,7 @@ export default function ResumePage() {
                 "@type": "ListItem",
                 position: 2,
                 name: "Resume/CV",
-                item: "https://www.jeff-bollinger.com/resume",
+                item: "https://www.jeff-bollinger.com/resume/",
               },
             ],
           }),


### PR DESCRIPTION
## Summary

- `trailingSlash: true` in `next.config.ts` causes `/resume` and `/publications` to 301 redirect to their `/` forms — Googlebot was flagging `/resume` as "Page with redirect" in Search Console
- Sitemap `<loc>` entries and `canonical` alternates pointed to the non-slash URLs, so Googlebot kept crawling the redirecting versions
- Breadcrumb schema `item` URLs updated to match

## Changes

- `sitemap.xml`: `/resume` → `/resume/`, `/publications` → `/publications/`, updated lastmod, removed stale commented-out `/project` entry
- `resume/page.tsx`: canonical and breadcrumb schema → `/resume/`
- `publications/layout.tsx`: canonical → `/publications/`
- `publications/page.tsx`: breadcrumb schema → `/publications/`

## Test plan

- [ ] CI passes
- [ ] After deploy: `curl -I https://www.jeff-bollinger.com/resume/` returns 200
- [ ] Trigger "Start New Validation" in Search Console for the resume redirect issue