### PR TITLE
docs: add stack badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,5 +2,8 @@
 
 [![Pages Production](https://github.com/jkeychan/jkeychan.github.io/actions/workflows/pages-prod.yml/badge.svg)](https://github.com/jkeychan/jkeychan.github.io/actions/workflows/pages-prod.yml)
 [![Workflow Security](https://github.com/jkeychan/jkeychan.github.io/actions/workflows/workflow-lint.yml/badge.svg)](https://github.com/jkeychan/jkeychan.github.io/actions/workflows/workflow-lint.yml)
+[![Next.js](https://img.shields.io/badge/Next.js-16-black?logo=nextdotjs&logoColor=white)](https://nextjs.org)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
+[![Tailwind CSS](https://img.shields.io/badge/Tailwind_CSS-4-38B2AC?logo=tailwindcss&logoColor=white)](https://tailwindcss.com)
 
 Source for [jeff-bollinger.com](https://www.jeff-bollinger.com) — built with Next.js, TypeScript, and Tailwind CSS, deployed to GitHub Pages.


### PR DESCRIPTION
## Summary
- Adds Next.js, TypeScript, and Tailwind CSS badges alongside the existing CI badges
- No LICENSE file exists in the repo, so no license badge was added
- No separate scheduled dependency-refresh workflow added — Dependabot already runs weekly against /site (.github/dependabot.yml), so a second workflow would be redundant

Note: shields.io was intermittently down while building this (some badge image requests timed out during testing) — URL structure and logo slugs (nextdotjs, typescript, tailwindcss) are correct per shields.io's static badge spec and simple-icons; the TypeScript badge round-tripped successfully during testing.